### PR TITLE
EDGOAIPMH-8 - "OAI-PMH: Response compression"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <junit.ver>4.12</junit.ver>
     <mockito.ver>1.9.5</mockito.ver>
     <rest.assured.ver>2.9.0</rest.assured.ver>
-    <edge.common.ver>0.3.4-SNAPSHOT</edge.common.ver>
+    <edge.common.ver>0.3.7-SNAPSHOT</edge.common.ver>
 
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.oaipmh.MainVerticle</exec.mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <junit.ver>4.12</junit.ver>
     <mockito.ver>1.9.5</mockito.ver>
     <rest.assured.ver>2.9.0</rest.assured.ver>
-    <edge.common.ver>0.3.7-SNAPSHOT</edge.common.ver>
+    <edge.common.ver>0.3.8-SNAPSHOT</edge.common.ver>
 
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.oaipmh.MainVerticle</exec.mainClass>

--- a/src/main/java/org/folio/edge/oaipmh/MainVerticle.java
+++ b/src/main/java/org/folio/edge/oaipmh/MainVerticle.java
@@ -3,13 +3,18 @@ package org.folio.edge.oaipmh;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
-import org.folio.edge.core.EdgeVerticle;
+import org.folio.edge.core.EdgeVerticle2;
 import org.folio.edge.oaipmh.utils.OaiPmhOkapiClientFactory;
 
-public class MainVerticle extends EdgeVerticle {
+import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
+import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
+
+public class MainVerticle extends EdgeVerticle2 {
 
   @Override
   public Router defineRoutes() {
+    String okapiURL = config().getString(SYS_OKAPI_URL);
+    int reqTimeoutMs = config().getInteger(SYS_REQUEST_TIMEOUT_MS);
     OaiPmhOkapiClientFactory ocf = new OaiPmhOkapiClientFactory(vertx, okapiURL, reqTimeoutMs);
     OaiPmhHandler oaiPmhHandler = new OaiPmhHandler(secureStore, ocf);
 

--- a/src/main/resources/ephemeral.properties
+++ b/src/main/resources/ephemeral.properties
@@ -1,9 +1,9 @@
 secureStore.type=Ephemeral
 # a comma separated list of tenants
-tenants=diku
+tenants=tenant
 #######################################################
 # For each tenant, the institutional user password...
 #
 # Note: this is intended for development purposes only
 #######################################################
-diku={DIKU_IU_PASSWORD}
+tenant=user,password

--- a/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
@@ -1,25 +1,14 @@
 package org.folio.edge.oaipmh;
 
-import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
-import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
-import static org.folio.edge.core.Constants.SYS_PORT;
-import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
-import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
-import static org.folio.edge.core.Constants.TEXT_PLAIN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.spy;
-
 import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.config.DecoderConfig;
+import com.jayway.restassured.response.Header;
 import com.jayway.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.http.HttpHeaders;
 import org.apache.log4j.Logger;
 import org.folio.edge.core.utils.ApiKeyUtils;
@@ -38,8 +27,24 @@ import org.openarchives.oai._2.VerbType;
 
 import javax.xml.bind.JAXBException;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
-
+import static com.jayway.restassured.config.DecoderConfig.decoderConfig;
+import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
+import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
+import static org.folio.edge.core.Constants.SYS_PORT;
+import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
+import static org.folio.edge.core.Constants.SYS_RESPONSE_COMPRESSION;
+import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
+import static org.folio.edge.core.Constants.TEXT_PLAIN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
 import static org.openarchives.oai._2.OAIPMHerrorcodeType.BAD_ARGUMENT;
 import static org.openarchives.oai._2.OAIPMHerrorcodeType.BAD_VERB;
 import static org.openarchives.oai._2.VerbType.LIST_IDENTIFIERS;
@@ -73,13 +78,15 @@ public class MainVerticleTest {
 
     vertx = Vertx.vertx();
 
-    System.setProperty(SYS_PORT, String.valueOf(serverPort));
-    System.setProperty(SYS_OKAPI_URL, "http://localhost:" + okapiPort);
-    System.setProperty(SYS_SECURE_STORE_PROP_FILE, "src/main/resources/ephemeral.properties");
-    System.setProperty(SYS_LOG_LEVEL, "DEBUG");
-    System.setProperty(SYS_REQUEST_TIMEOUT_MS, String.valueOf(requestTimeoutMs));
+    JsonObject jo = new JsonObject()
+      .put(SYS_PORT, serverPort)
+      .put(SYS_OKAPI_URL, "http://localhost:" + okapiPort)
+      .put(SYS_SECURE_STORE_PROP_FILE, "src/main/resources/ephemeral.properties")
+      .put(SYS_LOG_LEVEL, "TRACE")
+      .put(SYS_REQUEST_TIMEOUT_MS, requestTimeoutMs)
+      .put(SYS_RESPONSE_COMPRESSION, true);
 
-    final DeploymentOptions opt = new DeploymentOptions();
+    final DeploymentOptions opt = new DeploymentOptions().setConfig(jo);
     vertx.deployVerticle(MainVerticle.class.getName(), opt, context.asyncAssertSuccess());
 
     RestAssured.baseURI = "http://localhost:" + serverPort;
@@ -411,6 +418,54 @@ public class MainVerticleTest {
     String expectedRespStr = ResponseHelper.getInstance().writeToString(expectedResp);
 
     verifyResponse(expectedRespStr, resp.body().asString());
+  }
+
+  @Test
+  public void testCompressionAlgorithms() {
+    logger.info("=== Test response compression ===");
+
+    Path expectedMockPath = Paths.get(OaiPmhMockOkapi.PATH_TO_GET_RECORDS_MOCK);
+    String expectedMockBody = OaiPmhMockOkapi.getOaiPmhResponseAsXml(expectedMockPath);
+    int expectedHttpStatusCode = 200;
+
+    for (DecoderConfig.ContentDecoder type : DecoderConfig.ContentDecoder.values()) {
+      final Response resp = RestAssured.given()
+        .config(RestAssured.config().decoderConfig(decoderConfig().contentDecoders(type)))
+        .get(String.format("/oai?verb=GetRecord&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", apiKey))
+        .then()
+        .contentType(Constants.TEXT_XML_TYPE)
+        .statusCode(expectedHttpStatusCode)
+        .header(HttpHeaders.CONTENT_TYPE, Constants.TEXT_XML_TYPE)
+        .header(HttpHeaders.CONTENT_ENCODING, type.name().toLowerCase())
+        .extract()
+        .response();
+      assertEquals(expectedMockBody, resp.body().asString());
+    }
+  }
+
+  @Test
+  public void testNoCompression() {
+    logger.info("=== Test no response compression  ===");
+
+    Path expectedMockPath = Paths.get(OaiPmhMockOkapi.PATH_TO_GET_RECORDS_MOCK);
+    String expectedMockBody = OaiPmhMockOkapi.getOaiPmhResponseAsXml(expectedMockPath);
+    int expectedHttpStatusCode = 200;
+    final Response resp = RestAssured.given()
+      .config(RestAssured.config().decoderConfig(decoderConfig().noContentDecoders()))
+      .header(new Header(HttpHeaders.ACCEPT_ENCODING, "instance"))
+      .get(String.format("/oai?verb=GetRecord&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", apiKey))
+      .then()
+      .contentType(Constants.TEXT_XML_TYPE)
+      .statusCode(expectedHttpStatusCode)
+      .header(HttpHeaders.CONTENT_TYPE, Constants.TEXT_XML_TYPE)
+      .extract()
+      .response();
+
+    assertFalse(resp.headers().asList().stream()
+      .collect(Collectors.toMap(Header::getName, Header::getValue)).containsKey(HttpHeaders.ACCEPT_ENCODING));
+
+    String actualBody = resp.body().asString();
+    assertEquals(expectedMockBody, actualBody);
   }
 
   private OAIPMH buildOAIPMHErrorResponse(VerbType verb, OAIPMHerrorcodeType errorCode, String message) {

--- a/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
@@ -54,7 +54,7 @@ public class MainVerticleTest {
 
   private static final Logger logger = Logger.getLogger(MainVerticleTest.class);
 
-  private static final String apiKey = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
+  private static final String apiKey = "Z1luMHVGdjNMZl90ZW5hbnRfdXNlcg==";
   private static final String badApiKey = "ZnMwMDAwMDAwMA==0000";
 
   private static final long requestTimeoutMs = 3000L;
@@ -78,15 +78,14 @@ public class MainVerticleTest {
 
     vertx = Vertx.vertx();
 
-    JsonObject jo = new JsonObject()
-      .put(SYS_PORT, serverPort)
-      .put(SYS_OKAPI_URL, "http://localhost:" + okapiPort)
-      .put(SYS_SECURE_STORE_PROP_FILE, "src/main/resources/ephemeral.properties")
-      .put(SYS_LOG_LEVEL, "TRACE")
-      .put(SYS_REQUEST_TIMEOUT_MS, requestTimeoutMs)
-      .put(SYS_RESPONSE_COMPRESSION, true);
+    System.setProperty(SYS_PORT, String.valueOf(serverPort));
+    System.setProperty(SYS_OKAPI_URL, "http://localhost:" + okapiPort);
+    System.setProperty(SYS_SECURE_STORE_PROP_FILE, "src/main/resources/ephemeral.properties");
+    System.setProperty(SYS_LOG_LEVEL, "TRACE");
+    System.setProperty(SYS_REQUEST_TIMEOUT_MS, String.valueOf(requestTimeoutMs));
+    System.setProperty(SYS_RESPONSE_COMPRESSION, Boolean.toString(true));
 
-    final DeploymentOptions opt = new DeploymentOptions().setConfig(jo);
+    final DeploymentOptions opt = new DeploymentOptions();
     vertx.deployVerticle(MainVerticle.class.getName(), opt, context.asyncAssertSuccess());
 
     RestAssured.baseURI = "http://localhost:" + serverPort;


### PR DESCRIPTION
To enable response compression
- edge-common version switched from 0.3.4-SNAPSHOT to 0.3.7-SNAPSHOT;
- EdgeVerticle switched to EdgeVerticle2;
- unit tests added for compression verification.