### PR TITLE
Add ability to specify API Key as part of the path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@
     + RAML file
     + OAI-PMH Schema: [OAI-PMH.xsd](http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd) (please refer to [OAI-PMH specification](http://www.openarchives.org/OAI/openarchivesprotocol.html#OAIPMHschema) for more details)
  * POJO binding generation of [OAI-PMH.xsd](http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd) added in scope of [EDGOAIPMH-7](https://issues.folio.org/projects/EDGOAIPMH/issues/EDGOAIPMH-7)
- * Initial implmentation
-    + Details TBD
- * Added the ability to specify the API key on the path, e.g. `GET /oai/<apiKey>?verb=...` and `POST /oai/<apiKey>?verb=...`.  This will allow testing of incomplete responses/resumptionTokens via the marcEdit OAI-PMH harvester.  You can also specify the API Key via the Authorization header or the `apikey` (case sensitive) query argument.  See [Edge-Common](https://github.com/folio-org/edge-common/#api-key-sources) for details.
+ * Initial implementation
+    + To access the OAI-PMH repository the apiKey is required which might be provided as part of the URI path, `apikey` parameter or `Authorization` header. Please refer to [Security](https://github.com/folio-org/edge-common#security) section of the the [edge-common](https://github.com/folio-org/edge-common/blob/master/README.md) documentation for the details.
+    + The endpoint depends on authorization mechanism chosen. `GET` or `POST` requests are supported. Please refer to [edge-oai-pmh.raml](ramls/edge-oai-pmh.raml) for more details.
+    + Once the request is received, the flow is following:
+      1. The request is being validated if it valid according to OAI-PMH specification. If some parameters are missing or invalid, the OAI-PMH response with errors is sent back to harvester with `400` http status code.
+      2. The `apiKey` is being validated. In case it is missing or invalid, the response with error and `401` http status code is sent back to caller. If the apiKey of valid structure, the service tries to login to FOLIO system. If something is wrong, the response with error is sent back to caller with `403` or `408` http status code.
+      3. The request is sent to repository business logic. If something is wrong, the response with error is sent back to caller with `408` or `500` http status code. If all is okay, the OAI-PMH response is being sent to caller with `200`, `400`, `404` or `422` http status code.
+ * In scope of the [EDGCOMMON-8](https://issues.folio.org/browse/EDGCOMMON-8) support of the compression is added. By default it is disabled and can be activated by corresponding VM option. The `gzip` and `deflate` compressions supported.
+ * [EDGOAIPMH-24](https://issues.folio.org/browse/EDGOAIPMH-24): added the ability to specify the API key on the path, e.g. `GET /oai/<apiKey>?verb=...` and `POST /oai/<apiKey>?verb=...`.  This will allow testing of incomplete responses/resumptionTokens via the marcEdit OAI-PMH harvester.  You can also specify the API Key via the Authorization header or the `apikey` (case sensitive) query argument.  See [Edge-Common](https://github.com/folio-org/edge-common/#api-key-sources) for details.

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,3 +5,6 @@
     + RAML file
     + OAI-PMH Schema: [OAI-PMH.xsd](http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd) (please refer to [OAI-PMH specification](http://www.openarchives.org/OAI/openarchivesprotocol.html#OAIPMHschema) for more details)
  * POJO binding generation of [OAI-PMH.xsd](http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd) added in scope of [EDGOAIPMH-7](https://issues.folio.org/projects/EDGOAIPMH/issues/EDGOAIPMH-7)
+ * Initial implmentation
+    + Details TBD
+ * Added the ability to specify the API key on the path, e.g. `GET /oai/<apiKey>?verb=...` and `POST /oai/<apiKey>?verb=...`.  This will allow testing of incomplete responses/resumptionTokens via the marcEdit OAI-PMH harvester.  You can also specify the API Key via the Authorization header or the `apikey` (case sensitive) query argument.  See [Edge-Common](https://github.com/folio-org/edge-common/#api-key-sources) for details.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Edge API for Metadata Harvesting ([OAI-PMH Version 2.0](http://www.openarchives.
 ### Schemas
 The following schemas used:
  + OAI-PMH Schema: [OAI-PMH.xsd](http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd) (please refer to [OAI-PMH specification](http://www.openarchives.org/OAI/openarchivesprotocol.html#OAIPMHschema) for more details)
+### Configuration
+Please refer to the [Configuration](https://github.com/folio-org/edge-common/blob/master/README.md#configuration) section in the [edge-common](https://github.com/folio-org/edge-common/blob/master/README.md) documentation to see all available system properties and their default values.
+
+For example, to enable HTTP compression based on `Accept-Encoding` header the `-Dresponse_compression=true` should be specified as VM option.
 
 ### Issue tracker
 See project [EDGOAIPMH](https://issues.folio.org/browse/EDGOAIPMH)

--- a/ramls/edge-oai-pmh.raml
+++ b/ramls/edge-oai-pmh.raml
@@ -11,14 +11,23 @@ types:
 traits:
   resps: !include traits/resps.raml
   params: !include traits/params.raml
+  apiKeyParam: !include traits/apiKeyParam.raml
 /oai:
   displayName: OAI-PMH
   get:
     description: 'Run OAI-PMH request'
-    is: [params, resps]
+    is: [params, apiKeyParam, resps]
   post:
     description: 'Run OAI-PMH request'
-    is: [params, resps]
+    is: [params, apiKeyParam, resps]
+  /{apiKeyPath}:
+    displayName: OAI-PMH
+    get:
+      description: 'Run OAI-PMH request'
+      is: [params, resps]
+    post:
+      description: 'Run OAI-PMH request'
+      is: [params, resps]
 /admin/health:
   displayName: 'Health Check'
   get:

--- a/ramls/traits/apiKeyParam.raml
+++ b/ramls/traits/apiKeyParam.raml
@@ -1,0 +1,4 @@
+    queryParameters:
+      apikey:
+        description: 'API Key'
+        type: string

--- a/ramls/traits/params.raml
+++ b/ramls/traits/params.raml
@@ -13,11 +13,13 @@
         required: false
       from:
         description: 'UTC datetime value, which specifies a lower bound for datestamp-based selective harvesting'
-        type: date-only
+        type: datetime
+        example: 2018-11-25T16:17:18Z
         required: false
       until:
         description: 'UTC datetime value, which specifies a upper bound for datestamp-based selective harvesting'
-        type: date-only
+        type: datetime
+        example: 2018-11-28T14:15:16Z
         required: false
       set:
         description: 'SetSpec value, which specifies set criteria for selective harvesting'
@@ -27,6 +29,3 @@
         description: 'The flow control token returned by a ListIdentifiers request that issued an incomplete list'
         type: string
         required: false
-      apiKey:
-        description: 'API Key'
-        type: string

--- a/src/main/java/org/folio/edge/oaipmh/MainVerticle.java
+++ b/src/main/java/org/folio/edge/oaipmh/MainVerticle.java
@@ -1,13 +1,14 @@
 package org.folio.edge.oaipmh;
 
-import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.Router;
-import io.vertx.ext.web.handler.BodyHandler;
+import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
+import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
+
 import org.folio.edge.core.EdgeVerticle2;
 import org.folio.edge.oaipmh.utils.OaiPmhOkapiClientFactory;
 
-import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
-import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
 
 public class MainVerticle extends EdgeVerticle2 {
 
@@ -23,7 +24,9 @@ public class MainVerticle extends EdgeVerticle2 {
 
     router.route(HttpMethod.GET, "/admin/health").handler(this::handleHealthCheck);
     router.route(HttpMethod.GET, "/oai").handler(oaiPmhHandler::handle);
+    router.route(HttpMethod.GET, "/oai/:apiKeyPath").handler(oaiPmhHandler::handle);
     router.route(HttpMethod.POST, "/oai").handler(oaiPmhHandler::handle);
+    router.route(HttpMethod.POST, "/oai/:apiKeyPath").handler(oaiPmhHandler::handle);
 
     return router;
   }

--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -56,10 +56,10 @@ public class OaiPmhHandler extends Handler {
       logger.debug(request.method() + " " + request.absoluteURI());
       logger.debug("Client request parameters:");
       request.params()
-             .forEach(param -> logger.debug(param.getKey() + ": " + param.getValue()));
+             .forEach(param -> logger.debug(String.format("> %s: %s", param.getKey(), param.getValue())));
       logger.debug("Client request headers:");
       request.headers()
-             .forEach(header -> logger.debug(header.getKey() + ": " + header.getValue()));
+             .forEach(header -> logger.debug(String.format("> %s: %s", header.getKey(), header.getValue())));
     }
 
     Verb verb = Verb.fromName(request.getParam(VERB));
@@ -119,10 +119,15 @@ public class OaiPmhHandler extends Handler {
        * that all harvesters support such responses.
        */
       response.bodyHandler(buffer -> {
-        if (!encodingHeader.isPresent() && logger.isDebugEnabled()) {
-          logger.debug("Repository response body: " + buffer);
-        }
         edgeResponse.end(buffer);
+        if (logger.isDebugEnabled()) {
+          if (!encodingHeader.isPresent()) {
+            logger.debug("Repository response body: " + buffer);
+          }
+          logger.debug("Edge response headers:");
+          edgeResponse.headers()
+                      .forEach(header -> logger.debug(String.format("< %s: %s", header.getKey(), header.getValue())));
+        }
       });
     } else {
       logger.error(String.format("Error in the response from repository: (%d)", httpStatusCode));

--- a/src/main/java/org/folio/edge/oaipmh/Verb.java
+++ b/src/main/java/org/folio/edge/oaipmh/Verb.java
@@ -109,6 +109,10 @@ public enum Verb {
     return optionalParams;
   }
 
+  public Set<String> getExcludedParams() {
+    return excludeParams;
+  }
+
   public String getExclusiveParam() {
     return exclusiveParam;
   }
@@ -123,7 +127,6 @@ public enum Verb {
     ctx.request().params().entries().stream()
       .map(Entry::getKey)
       .filter(param -> !allParams.contains(param))
-      .filter(param -> !excludeParams.contains(param))
       .forEach(param -> errors.add(new OAIPMHerrorType()
         .withCode(BAD_ARGUMENT)
         .withValue("Verb '" + name + "', illegal argument: " + param)));

--- a/src/main/java/org/folio/edge/oaipmh/Verb.java
+++ b/src/main/java/org/folio/edge/oaipmh/Verb.java
@@ -55,7 +55,8 @@ public enum Verb {
   /** ISO Date and Time with UTC offset. */
   private static final DateTimeFormatter ISO_UTC_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
   /** Parameters which must be excluded from validation if present in http request. */
-  private final Set<String> excludeParams = of(VERB, PARAM_API_KEY, PATH_API_KEY);
+  /** convert the api-key params to lowercase so we can lowercase those on the request to ignore case later on" */
+  private final Set<String> excludeParams = of(VERB, PARAM_API_KEY.toLowerCase(), PATH_API_KEY.toLowerCase());
 
   private static final Map<String, Verb> CONSTANTS = new HashMap<>();
   static {
@@ -123,6 +124,7 @@ public enum Verb {
     ctx.request().params().entries().stream()
       .map(Entry::getKey)
       .filter(param -> !allParams.contains(param))
+      .filter(param -> !excludeParams.contains(param.toLowerCase())) //support case-insensitive api-key params
       .forEach(param -> errors.add(new OAIPMHerrorType()
         .withCode(BAD_ARGUMENT)
         .withValue("Verb '" + name + "', illegal argument: " + param)));
@@ -132,7 +134,7 @@ public enum Verb {
     if (exclusiveParam != null && ctx.request().getParam(exclusiveParam) != null) {
       ctx.request().params().entries().stream()
         .map(Entry::getKey)
-        .filter(p -> !excludeParams.contains(p))
+        .filter(p -> !excludeParams.contains(p.toLowerCase())) //support case-insensitive api-key params
         .filter(p -> !exclusiveParam.equals(p))
         .findAny()
         .ifPresent(param -> errors.add(new OAIPMHerrorType()

--- a/src/main/java/org/folio/edge/oaipmh/Verb.java
+++ b/src/main/java/org/folio/edge/oaipmh/Verb.java
@@ -55,8 +55,7 @@ public enum Verb {
   /** ISO Date and Time with UTC offset. */
   private static final DateTimeFormatter ISO_UTC_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
   /** Parameters which must be excluded from validation if present in http request. */
-  /** convert the api-key params to lowercase so we can lowercase those on the request to ignore case later on" */
-  private final Set<String> excludeParams = of(VERB, PARAM_API_KEY.toLowerCase(), PATH_API_KEY.toLowerCase());
+  private final Set<String> excludeParams = of(VERB, PARAM_API_KEY, PATH_API_KEY);
 
   private static final Map<String, Verb> CONSTANTS = new HashMap<>();
   static {
@@ -124,7 +123,7 @@ public enum Verb {
     ctx.request().params().entries().stream()
       .map(Entry::getKey)
       .filter(param -> !allParams.contains(param))
-      .filter(param -> !excludeParams.contains(param.toLowerCase())) //support case-insensitive api-key params
+      .filter(param -> !excludeParams.contains(param))
       .forEach(param -> errors.add(new OAIPMHerrorType()
         .withCode(BAD_ARGUMENT)
         .withValue("Verb '" + name + "', illegal argument: " + param)));
@@ -134,7 +133,7 @@ public enum Verb {
     if (exclusiveParam != null && ctx.request().getParam(exclusiveParam) != null) {
       ctx.request().params().entries().stream()
         .map(Entry::getKey)
-        .filter(p -> !excludeParams.contains(p.toLowerCase())) //support case-insensitive api-key params
+        .filter(p -> !excludeParams.contains(p))
         .filter(p -> !exclusiveParam.equals(p))
         .findAny()
         .ifPresent(param -> errors.add(new OAIPMHerrorType()

--- a/src/main/java/org/folio/edge/oaipmh/Verb.java
+++ b/src/main/java/org/folio/edge/oaipmh/Verb.java
@@ -1,7 +1,19 @@
 package org.folio.edge.oaipmh;
 
-import io.vertx.ext.web.RoutingContext;
-import org.openarchives.oai._2.OAIPMHerrorType;
+import static com.google.common.collect.ImmutableSet.of;
+import static java.util.Collections.EMPTY_SET;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Stream.concat;
+import static org.folio.edge.core.Constants.PARAM_API_KEY;
+import static org.folio.edge.core.Constants.PATH_API_KEY;
+import static org.folio.edge.oaipmh.utils.Constants.FROM;
+import static org.folio.edge.oaipmh.utils.Constants.IDENTIFIER;
+import static org.folio.edge.oaipmh.utils.Constants.METADATA_PREFIX;
+import static org.folio.edge.oaipmh.utils.Constants.RESUMPTION_TOKEN;
+import static org.folio.edge.oaipmh.utils.Constants.SET;
+import static org.folio.edge.oaipmh.utils.Constants.UNTIL;
+import static org.folio.edge.oaipmh.utils.Constants.VERB;
+import static org.openarchives.oai._2.OAIPMHerrorcodeType.BAD_ARGUMENT;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -13,19 +25,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import static com.google.common.collect.ImmutableSet.of;
-import static java.util.Collections.EMPTY_SET;
-import static java.util.stream.Collectors.toSet;
-import static java.util.stream.Stream.concat;
-import static org.folio.edge.core.Constants.PARAM_API_KEY;
-import static org.folio.edge.oaipmh.utils.Constants.FROM;
-import static org.folio.edge.oaipmh.utils.Constants.IDENTIFIER;
-import static org.folio.edge.oaipmh.utils.Constants.METADATA_PREFIX;
-import static org.folio.edge.oaipmh.utils.Constants.RESUMPTION_TOKEN;
-import static org.folio.edge.oaipmh.utils.Constants.SET;
-import static org.folio.edge.oaipmh.utils.Constants.UNTIL;
-import static org.folio.edge.oaipmh.utils.Constants.VERB;
-import static org.openarchives.oai._2.OAIPMHerrorcodeType.BAD_ARGUMENT;
+import org.openarchives.oai._2.OAIPMHerrorType;
+
+import io.vertx.ext.web.RoutingContext;
 
 /**
  * Enum that represents OAI-PMH verbs with associated http parameters and validation logic.
@@ -53,7 +55,7 @@ public enum Verb {
   /** ISO Date and Time with UTC offset. */
   private static final DateTimeFormatter ISO_UTC_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
   /** Parameters which must be excluded from validation if present in http request. */
-  private final Set<String> excludeParams = of(VERB, PARAM_API_KEY);
+  private final Set<String> excludeParams = of(VERB, PARAM_API_KEY, PATH_API_KEY);
 
   private static final Map<String, Verb> CONSTANTS = new HashMap<>();
   static {

--- a/src/main/java/org/folio/edge/oaipmh/utils/OaiPmhOkapiClient.java
+++ b/src/main/java/org/folio/edge/oaipmh/utils/OaiPmhOkapiClient.java
@@ -1,28 +1,28 @@
 package org.folio.edge.oaipmh.utils;
 
-import static com.google.common.collect.ImmutableSet.of;
-import static java.util.stream.Collectors.joining;
-import static org.folio.edge.core.Constants.PARAM_API_KEY;
-import static org.folio.edge.oaipmh.utils.Constants.VERB;
-
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientResponse;
+import org.apache.log4j.Logger;
+import org.folio.edge.core.utils.OkapiClient;
+import org.folio.edge.oaipmh.Verb;
+import org.openarchives.oai._2.VerbType;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.log4j.Logger;
-import org.folio.edge.core.utils.OkapiClient;
-import org.openarchives.oai._2.VerbType;
+
+import static io.vertx.core.http.HttpHeaders.CONTENT_LENGTH;
+import static java.util.stream.Collectors.joining;
+import static org.folio.edge.oaipmh.utils.Constants.VERB;
 
 public class OaiPmhOkapiClient extends OkapiClient {
 
   private static final String URL_ENCODING_TYPE = "UTF-8";
-  private static final Set<String> EXCLUDED_PARAMS = of(VERB, PARAM_API_KEY);
-  public static final String CONTENT_LENGTH_HEADER = "Content-Length";
+
   private static Logger logger = Logger.getLogger(OaiPmhOkapiClient.class);
   private static Map<String, String> endpointsMap = new HashMap<>();
 
@@ -55,7 +55,7 @@ public class OaiPmhOkapiClient extends OkapiClient {
     String url = getUrlByVerb(parameters);
     // "Content-Length" header appearing from POST request to edge-oai-pmh API should be removed as unnecessary
     // for GET request to mod-oai-pmh
-    headers.remove(CONTENT_LENGTH_HEADER);
+    headers.remove(CONTENT_LENGTH);
     get(
       url,
       tenant,
@@ -94,8 +94,9 @@ public class OaiPmhOkapiClient extends OkapiClient {
    * @return string representation of GET request parameters
    */
   private String getParametersAsString(MultiMap parameters) {
+    Set<String> excludedParams = Verb.fromName(parameters.get(VERB)).getExcludedParams();
     return parameters.entries().stream()
-      .filter(e -> !EXCLUDED_PARAMS.contains(e.getKey()))
+      .filter(e -> !excludedParams.contains(e.getKey()))
       .map(e -> e.getKey() + "=" + e.getValue())
       .collect(joining("&"));
   }

--- a/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
@@ -282,6 +282,26 @@ public class MainVerticleTest {
   }
 
   @Test
+  public void testApiKeyOnPath() {
+    logger.info("=== Test ability to provide the api key on the path ===");
+
+    Path expectedMockPath = Paths.get(OaiPmhMockOkapi.PATH_TO_IDENTIFY_MOCK);
+    String expectedMockBody = OaiPmhMockOkapi.getOaiPmhResponseAsXml(expectedMockPath);
+    int expectedHttpStatusCode = 200;
+    final Response resp = RestAssured
+      .get(String.format("/oai/%s?verb=Identify", apiKey))
+      .then()
+      .contentType(Constants.TEXT_XML_TYPE)
+      .statusCode(expectedHttpStatusCode)
+      .header(HttpHeaders.CONTENT_TYPE, Constants.TEXT_XML_TYPE)
+      .extract()
+      .response();
+
+    String actualBody = resp.body().asString();
+    assertEquals(expectedMockBody, actualBody);
+  }
+
+  @Test
   public void testIdentifyAccessDeniedApiKeyHttpGet() {
     logger.info("=== Test Access Denied apikey Identify OAI-PMH (HTTP POST) ===");
 

--- a/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
@@ -6,7 +6,6 @@ import com.jayway.restassured.response.Header;
 import com.jayway.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpHeaders;
@@ -57,7 +56,7 @@ public class MainVerticleTest {
   private static final Logger logger = Logger.getLogger(MainVerticleTest.class);
 
   private static final String apiKey = "Z1luMHVGdjNMZl90ZW5hbnRfdXNlcg==";
-  private static final String apiKeyForDikuUser = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
+  private static final String apiKeyForTestUser = "Z1luMHVGdjNMZl90ZXN0X3Rlc3Q=";
   private static final String badApiKey = "ZnMwMDAwMDAwMA==0000";
 
   private static final long requestTimeoutMs = REQUEST_TIMEOUT_MS;
@@ -306,7 +305,7 @@ public class MainVerticleTest {
     logger.info("=== Test Access Denied apikey Identify OAI-PMH (HTTP POST) ===");
 
     final Response resp = RestAssured
-      .post(String.format("/oai?verb=Identify&apikey=%s", apiKeyForDikuUser))
+      .post(String.format("/oai?verb=Identify&apikey=%s", apiKeyForTestUser))
       .then()
       .contentType(TEXT_PLAIN)
       .statusCode(403)

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -3,6 +3,6 @@ log4j.rootLogger=DEBUG, CONSOLE
 # CONSOLE is set to be a ConsoleAppender using a PatternLayout.
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p [%-25t]: %-20.25C{1} %X{reqId} %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p [%-25t]: %C{1} %m%n
 
 log4j.logger.io.netty=INFO


### PR DESCRIPTION
This is supported by edge-common, but we need to make a few adjustments here to make this work.

Added:
- `GET /oai/<apiKey>?verb=...`
- `POST /oai/<apiKey>?verb=...`