### PR TITLE
Add support of ISO8601 date without time format for from/until params

### DIFF
--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -172,6 +172,7 @@ public class OaiPmhHandler extends Handler {
     ctx.response().setStatusCode(status);
 
     if (xml != null) {
+      logger.warn("The request was invalid. The response returned with errors: " + xml);
       ctx.response()
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_XML)
         .end(xml);

--- a/src/main/java/org/folio/edge/oaipmh/Verb.java
+++ b/src/main/java/org/folio/edge/oaipmh/Verb.java
@@ -15,6 +15,7 @@ import static org.folio.edge.oaipmh.utils.Constants.UNTIL;
 import static org.folio.edge.oaipmh.utils.Constants.VERB;
 import static org.openarchives.oai._2.OAIPMHerrorcodeType.BAD_ARGUMENT;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -150,9 +151,14 @@ public enum Verb {
     try {
       LocalDateTime.parse(paramValue, ISO_UTC_DATE_TIME);
     } catch (DateTimeParseException e) {
-      errors.add(new OAIPMHerrorType()
-        .withCode(BAD_ARGUMENT)
-        .withValue("Bad datestamp format for '" + paramName + "' argument."));
+      // The repository must support YYYY-MM-DD granularity so try to parse date only
+      try {
+        LocalDate.parse(paramValue);
+      } catch (DateTimeParseException ex) {
+        errors.add(new OAIPMHerrorType()
+          .withCode(BAD_ARGUMENT)
+          .withValue("Bad datestamp format for '" + paramName + "' argument."));
+      }
     }
   }
 }

--- a/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
@@ -401,7 +401,7 @@ public class MainVerticleTest {
     logger.info("=== Test validate w/ illegal params ===");
 
     final Response resp = RestAssured
-      .get("/oai?verb=ListIdentifiers&metadataPrefix=oai_dc&extraParam=Test&apikey=" + apiKey)
+      .get("/oai?verb=ListIdentifiers&metadataPrefix=oai_dc&from=2002-05-21&extraParam=Test&apikey=" + apiKey)
       .then()
       .contentType("text/xml")
       .statusCode(400)
@@ -411,7 +411,8 @@ public class MainVerticleTest {
     OAIPMH expectedResp = buildOAIPMHErrorResponse(LIST_IDENTIFIERS, BAD_ARGUMENT,
         "Verb 'ListIdentifiers', illegal argument: extraParam");
     expectedResp.getRequest()
-                .withMetadataPrefix("oai_dc");
+                .withMetadataPrefix("oai_dc")
+                .withFrom("2002-05-21");
     String expectedRespStr = ResponseHelper.getInstance().writeToString(expectedResp);
 
     verifyResponse(expectedRespStr, resp.body().asString());


### PR DESCRIPTION
According to OAI-PMH specification: "All repositories must support YYYY-MM-DD. A request by a harvester with finer granularity than that supported by a repository must produce an error."