### PR TITLE
EDGOAIPMH-26 - Missing required login interface in module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -6,6 +6,10 @@
     {
       "id": "oai-pmh",
       "version": "1.0"
+    },
+    {
+      "id": "login",
+      "version": "5.0"
     }
   ],
   "permissionSets": [],


### PR DESCRIPTION
Login interface version 5.0 added in Module Descriptor.