### PR TITLE
EDGOAIPMH-28 - Release 2.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+## 2.0.0 (Released on 03/09/2019)
+
+The main focus of this release was to upgrade login interface and edge-common dependency to actual versions.
+
+[Full Changelog](https://github.com/folio-org/edge-oai-pmh/compare/v1.0.0...v2.0.0)
+
+### Stories
+ * [EDGOAIPMH-26](https://issues.folio.org/browse/EDGOAIPMH-26): login 5.0 interface has been added to the required interfaces in the module descriptor.
+ * [EDGOAIPMH-28](https://issues.folio.org/browse/EDGOAIPMH-28): the edge-common dependency upgraded to version 2.0.0 in order to leverage the new API key structure.
+
 ## 1.0.0 (Released on 11/27/2018)
  * Initial commit ([EDGOAIPMH-2](https://issues.folio.org/projects/EDGOAIPMH/issues/EDGOAIPMH-2))
  * Module/Deployment Descriptors added in scope of [EDGOAIPMH-5](https://issues.folio.org/projects/EDGOAIPMH/issues/EDGOAIPMH-5)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>2.0.0</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>v1.0.0</tag>
+    <tag>v2.0.0</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>v2.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>


### PR DESCRIPTION
The main focus of this release (edge-oai-pmh-2.0.0) was to upgrade login interface and edge-common dependency to actual versions.