### PR TITLE
Release 2.1.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 ## 2.2.0 - Unreleased
 
+## 2.1.1 - Released
+
+This is a bugfix release for inclusion in Edelweiss (Q4/2019).  The only change is to update the dependency version of the 'oai' interface
+
+[Full Changelog](https://github.com/folio-org/edge-oai-pmh/compare/v2.1.0...v2.1.1)
+
 ## 2.1.0 - Released
 
 This release includes tuning environment settings

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,7 +5,7 @@
   "requires": [
     {
       "id": "oai-pmh",
-      "version": "1.1"
+      "version": "1.1 2.0"
     },
     {
       "id": "login",

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.1.1</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>v2.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.1.1</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.1.1</tag>
   </scm>
 
   <licenses>


### PR DESCRIPTION
## Purpose
Release v2.1.1 for inclusion in Edelweiss (Q4/2019)

See [EDGOAIPMH-37](https://issues.folio.org/browse/EDGOAIPMH-37)

NOTE: I have not yet run the mvn command to bump the versions and create the tag