### PR TITLE
EDGOAIPMH-39 Don't pass Accept header to backend

### DIFF
--- a/src/main/java/org/folio/edge/oaipmh/utils/OaiPmhOkapiClient.java
+++ b/src/main/java/org/folio/edge/oaipmh/utils/OaiPmhOkapiClient.java
@@ -46,6 +46,9 @@ public class OaiPmhOkapiClient extends OkapiClient {
     fixDefaultHeaders();
   }
 
+  // EDGOAIPMH-39 - the defaultHeaders map from OkapiClient (edge-common) contains
+  // Accept: application/json, text/plain
+  // so we need to strip that out too...
   private void fixDefaultHeaders() {
     defaultHeaders.remove(ACCEPT);
   }

--- a/src/main/java/org/folio/edge/oaipmh/utils/OaiPmhOkapiClient.java
+++ b/src/main/java/org/folio/edge/oaipmh/utils/OaiPmhOkapiClient.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.vertx.core.http.HttpHeaders.CONTENT_LENGTH;
+import static io.vertx.core.http.HttpHeaders.ACCEPT;
 import static java.util.stream.Collectors.joining;
 import static org.folio.edge.oaipmh.utils.Constants.VERB;
 
@@ -37,10 +38,16 @@ public class OaiPmhOkapiClient extends OkapiClient {
 
   public OaiPmhOkapiClient(OkapiClient client) {
     super(client);
+    fixDefaultHeaders();
   }
 
   OaiPmhOkapiClient(Vertx vertx, String okapiURL, String tenant, long timeout) {
     super(vertx, okapiURL, tenant, timeout);
+    fixDefaultHeaders();
+  }
+
+  private void fixDefaultHeaders() {
+    defaultHeaders.remove(ACCEPT);
   }
 
   /**
@@ -56,6 +63,8 @@ public class OaiPmhOkapiClient extends OkapiClient {
     // "Content-Length" header appearing from POST request to edge-oai-pmh API should be removed as unnecessary
     // for GET request to mod-oai-pmh
     headers.remove(CONTENT_LENGTH);
+    // EDGOAIPMH-39
+    headers.remove(ACCEPT);
     get(
       url,
       tenant,

--- a/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
@@ -536,7 +536,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .given()
-      .header(ACCEPT.toString(), "bogus")
+      .header(HttpHeaders.ACCEPT.toString(), "bogus")
       .get(String.format("/oai?verb=GetRecord"
         + "&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", API_KEY))
       .then()

--- a/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
@@ -527,6 +527,52 @@ public class MainVerticleTest {
     assertEquals(expectedMockBody, actualBody);
   }
 
+  @Test
+  public void testAcceptHeader() {
+    logger.info("=== Test handling of the Accept header ===");
+
+    Path expectedMockPath = Paths.get(OaiPmhMockOkapi.PATH_TO_GET_RECORDS_MOCK);
+    String expectedMockBody = OaiPmhMockOkapi.getOaiPmhResponseAsXml(expectedMockPath);
+
+    final Response resp = RestAssured
+      .given()
+      .header(ACCEPT.toString(), "bogus")
+      .get(String.format("/oai?verb=GetRecord"
+        + "&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", API_KEY))
+      .then()
+      .log().all()
+      .contentType(Constants.TEXT_XML_TYPE)
+      .statusCode(HttpStatus.SC_OK)
+      .header(HttpHeaders.CONTENT_TYPE, Constants.TEXT_XML_TYPE)
+      .extract()
+      .response();
+
+    String actualBody = resp.body().asString();
+    assertEquals(expectedMockBody, actualBody);
+  }
+
+  @Test
+  public void testNoAcceptHeader() {
+    logger.info("=== Test handling of the Accept header ===");
+
+    Path expectedMockPath = Paths.get(OaiPmhMockOkapi.PATH_TO_GET_RECORDS_MOCK);
+    String expectedMockBody = OaiPmhMockOkapi.getOaiPmhResponseAsXml(expectedMockPath);
+
+    final Response resp = RestAssured
+      .get(String.format("/oai?verb=GetRecord"
+        + "&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", API_KEY))
+      .then()
+      .log().all()
+      .contentType(Constants.TEXT_XML_TYPE)
+      .statusCode(HttpStatus.SC_OK)
+      .header(HttpHeaders.CONTENT_TYPE, Constants.TEXT_XML_TYPE)
+      .extract()
+      .response();
+
+    String actualBody = resp.body().asString();
+    assertEquals(expectedMockBody, actualBody);
+  }
+
   private OAIPMH buildOAIPMHErrorResponse(VerbType verb, OAIPMHerrorcodeType errorCode, String message) {
     return new OAIPMH()
       .withRequest(new RequestType()

--- a/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java
+++ b/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java
@@ -74,8 +74,17 @@ public class OaiPmhMockOkapi extends MockOkapi {
 
     HttpServerRequest request = ctx.request();
     String path = request.path();
+    String accept = request.getHeader(HttpHeaders.ACCEPT);
 
-    if (path.startsWith("/oai/records/")
+    if(accept != null && (
+        !accept.equals(Constants.TEXT_XML_TYPE) ||
+        !accept.equals("*/*"))) {
+      logger.debug("Unsupported MIME type requested: " + accept);
+      ctx.response()
+        .setStatusCode(400)
+        .putHeader(HttpHeaders.CONTENT_TYPE, "text/plain")
+        .end("Accept header must be [\"application/xml\",\"text/plain\"] for this request, but it is \"text/xml\", cannot send */*");
+    } else if (path.startsWith("/oai/records/")
       && path.contains("oai%3AarXiv.org%3Acs%2F0112017")) {
       ctx.response()
         .setStatusCode(200)


### PR DESCRIPTION
## Purpose
Provide a fix for the problem described MODOAIPMH-86 that's compatible with the Daisy release of FOLIO.

This can be achieved by simply not passing the "Accept" header when proxying requests to mod-oai-pmh.  If no Accept header is provided, or `*/*` is specified, mod-oai-pmh will service the request and return text/xml as expected per the OAI-PMH spec.

See [EDGOAIPMH-39](https://issues.folio.org/browse/EDGOAIPMH-39)