### PR TITLE
EDGOAIPMH-38 Use "Accept: text/xml" or empty Accept when making requests to mod-oai-pmh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/ramls/traits/resps.raml
+++ b/ramls/traits/resps.raml
@@ -19,6 +19,10 @@
         body:
           text/xml:
             schema: OAI-PMH
+      '406':
+        description: 'Not Acceptable'
+        body:
+          text/xml:
       '422':
         description: 'Unprocessable Entity'
         body:

--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -64,9 +64,8 @@ public class OaiPmhHandler extends Handler {
              .forEach(header -> logger.debug(String.format("> %s: %s", header.getKey(), header.getValue())));
     }
 
-    if (request.headers().contains(ACCEPT)
-              && !request.headers().getAll(ACCEPT).stream().allMatch(value -> value.equals(EMPTY_ACCEPT_HEADER))
-              && !request.headers().getAll(ACCEPT).stream().allMatch(val -> val.equals(TEXT_XML_TYPE))) {
+    if (!request.headers().isEmpty() && request.headers().contains(ACCEPT)
+          && !request.headers().get(ACCEPT).equals(EMPTY_ACCEPT_HEADER) && !request.headers().get(ACCEPT).equals(TEXT_XML_TYPE)) {
       handleNotAcceptableError(ctx, request);
       return;
     }

--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -65,7 +65,8 @@ public class OaiPmhHandler extends Handler {
     }
 
     if (!request.headers().isEmpty() && request.headers().contains(ACCEPT)
-              && request.headers().getAll(ACCEPT).stream().noneMatch(value -> value.equals(EMPTY_ACCEPT_HEADER) || value.equals(TEXT_XML_TYPE))) {
+              && request.headers().getAll(ACCEPT).stream().noneMatch(value -> value.equals(EMPTY_ACCEPT_HEADER)
+              || value.equals(TEXT_XML_TYPE))) {
       handleNotAcceptableError(ctx, request);
       return;
     }
@@ -229,7 +230,7 @@ public class OaiPmhHandler extends Handler {
       .stream()
       .filter(value -> (!value.equals(TEXT_XML_TYPE)))
       .findFirst()
-      .orElse(null);
+      .orElse("");
     notAcceptable(ctx,
         "Accept header must be \"text/xml\" for this request, but it is " + "\"" + unsupportedType + "\"" + ", can not send */*");
   }

--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -65,7 +65,7 @@ public class OaiPmhHandler extends Handler {
     }
 
     if (!request.headers().isEmpty() && request.headers().contains(ACCEPT)
-          && !request.headers().get(ACCEPT).equals(EMPTY_ACCEPT_HEADER) && !request.headers().get(ACCEPT).equals(TEXT_XML_TYPE)) {
+              && request.headers().getAll(ACCEPT).stream().noneMatch(value -> value.equals(EMPTY_ACCEPT_HEADER) || value.equals(TEXT_XML_TYPE))) {
       handleNotAcceptableError(ctx, request);
       return;
     }

--- a/src/main/java/org/folio/edge/oaipmh/utils/Constants.java
+++ b/src/main/java/org/folio/edge/oaipmh/utils/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
   public static final String SET = "set";
   public static final String RESUMPTION_TOKEN = "resumptionToken";
   public static final String MOD_OAI_PMH_ACCEPTED_TYPES = "application/xml, text/xml";
+  public static final String EMPTY_ACCEPT_HEADER = "*/*";
 
   private Constants() {
   }

--- a/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
@@ -598,6 +598,30 @@ public class MainVerticleTest {
     assertEquals(expectedBody, actualBody);
   }
 
+  @Test
+  public void testAcceptHeaderIsAbsent() {
+    logger.info("=== Test Accept header is absent ===");
+
+    Path expectedMockPath = Paths.get(OaiPmhMockOkapi.PATH_TO_GET_RECORDS_MOCK);
+    String expectedMockBody = OaiPmhMockOkapi.getOaiPmhResponseAsXml(expectedMockPath);
+
+    final Response resp = RestAssured
+      .given()
+      .header(HttpHeaders.ACCEPT_CHARSET, "utf-8")
+      .get(String.format("/oai?verb=GetRecord"
+        + "&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", API_KEY))
+      .then()
+      .log().all()
+      .contentType(Constants.TEXT_XML_TYPE)
+      .statusCode(HttpStatus.SC_OK)
+      .header(HttpHeaders.CONTENT_TYPE, Constants.TEXT_XML_TYPE)
+      .extract()
+      .response();
+
+    String actualBody = resp.body().asString();
+    assertEquals(expectedMockBody, actualBody);
+  }
+
   private OAIPMH buildOAIPMHErrorResponse(VerbType verb, OAIPMHerrorcodeType errorCode, String message) {
     return new OAIPMH()
       .withRequest(new RequestType()

--- a/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
@@ -536,7 +536,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .given()
-      .header(HttpHeaders.ACCEPT.toString(), "bogus")
+      .header(HttpHeaders.ACCEPT, TEXT_XML)
       .get(String.format("/oai?verb=GetRecord"
         + "&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", API_KEY))
       .then()
@@ -571,6 +571,31 @@ public class MainVerticleTest {
 
     String actualBody = resp.body().asString();
     assertEquals(expectedMockBody, actualBody);
+  }
+
+  @Test
+  public void testAcceptHeaderHasUnsupportedType() {
+    logger.info("=== Test handling of unsupported type in Accept header ===");
+
+    String unsupportedAcceptType = "application/json";
+
+    final Response resp = RestAssured
+      .given()
+      .header(HttpHeaders.ACCEPT, unsupportedAcceptType)
+      .get(String.format("/oai?verb=GetRecord"
+        + "&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", API_KEY))
+      .then()
+      .log().all()
+      .contentType(Constants.TEXT_XML_TYPE)
+      .statusCode(HttpStatus.SC_NOT_ACCEPTABLE)
+      .header(HttpHeaders.CONTENT_TYPE, Constants.TEXT_XML_TYPE)
+      .extract()
+      .response();
+
+    String actualBody = resp.body().asString();
+    String expectedBody = "Accept header must be \"text/xml\" for this request, but it is " +"\""+ unsupportedAcceptType
+      +"\""+", can not send */*";
+    assertEquals(expectedBody, actualBody);
   }
 
   private OAIPMH buildOAIPMHErrorResponse(VerbType verb, OAIPMHerrorcodeType errorCode, String message) {

--- a/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/MainVerticleTest.java
@@ -622,6 +622,30 @@ public class MainVerticleTest {
     assertEquals(expectedMockBody, actualBody);
   }
 
+  @Test
+  public void testAcceptHeaderIsEmpty() {
+    logger.info("=== Test Accept header is empty ===");
+
+    Path expectedMockPath = Paths.get(OaiPmhMockOkapi.PATH_TO_GET_RECORDS_MOCK);
+    String expectedMockBody = OaiPmhMockOkapi.getOaiPmhResponseAsXml(expectedMockPath);
+
+    final Response resp = RestAssured
+      .given()
+      .header(HttpHeaders.ACCEPT, "*/*")
+      .get(String.format("/oai?verb=GetRecord"
+        + "&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", API_KEY))
+      .then()
+      .log().all()
+      .contentType(Constants.TEXT_XML_TYPE)
+      .statusCode(HttpStatus.SC_OK)
+      .header(HttpHeaders.CONTENT_TYPE, Constants.TEXT_XML_TYPE)
+      .extract()
+      .response();
+
+    String actualBody = resp.body().asString();
+    assertEquals(expectedMockBody, actualBody);
+  }
+
   private OAIPMH buildOAIPMHErrorResponse(VerbType verb, OAIPMHerrorcodeType errorCode, String message) {
     return new OAIPMH()
       .withRequest(new RequestType()


### PR DESCRIPTION
If Accept header is empty or has text/xml value edge-oai-pmh module making requests to mod-oai-pmh otherwise, a 406 Http code is sent.