### PR TITLE
MODOAIPMH-106 Get okapi token and tenant not from headers

### DIFF
--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -901,24 +901,6 @@ public class OaiPmhTest {
 }
 
   @Test
-  public void testMakeRequestWithInvalidTenant(){
-    logger.info("=== Test make request with invalid tenant ===");
-
-    final Response resp = RestAssured
-      .given()
-      .header("x-okapi-tenant","tenant")
-      .get("/oai/" + API_KEY + "?verb=ListRecords")
-      .then()
-      .log().all()
-      .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-      .extract()
-      .response();
-
-    String actualBody = resp.body().asString();
-    assertTrue(actualBody.contains("Exception"));
-  }
-
-  @Test
   public void testMakeRequestAndGetResponseWithEmptyBody(){
     logger.info("=== Test make request and give response with empty body ===");
 


### PR DESCRIPTION
### PURPOSE
In order for not to use okapi token and tenant from headers, I override method (I leave the logic of getting the token and tenant ) and use this method for giving ConfigurationsClient. For make request to oai-pmh I use version of this method from parent class.

### LINK 
[https://issues.folio.org/browse/MODOAIPMH-106](url)