### PR TITLE
Implement configuration settings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following schemas used:
 ### Required Permissions
 Institutional users should be granted the following permissions in order to use this edge API:
 - `oai-pmh.all`
+- `configuration.entries.collection.get`
 
 ### Configuration
 Please refer to the [Configuration](https://github.com/folio-org/edge-common/blob/master/README.md#configuration) section in the [edge-common](https://github.com/folio-org/edge-common/blob/master/README.md) documentation to see all available system properties and their default values.

--- a/src/main/java/org/folio/edge/oaipmh/MainVerticle.java
+++ b/src/main/java/org/folio/edge/oaipmh/MainVerticle.java
@@ -25,7 +25,6 @@ public class MainVerticle extends EdgeVerticle2 {
     Router router = Router.router(vertx);
     router.route().handler(BodyHandler.create());
 
-
     router.route(HttpMethod.GET, "/admin/health").handler(this::handleHealthCheck);
     router.route(HttpMethod.GET, "/oai").handler(oaiPmhHandler::handle);
     router.route(HttpMethod.GET, "/oai/:apiKeyPath").handler(oaiPmhHandler::handle);

--- a/src/main/java/org/folio/edge/oaipmh/MainVerticle.java
+++ b/src/main/java/org/folio/edge/oaipmh/MainVerticle.java
@@ -23,7 +23,9 @@ public class MainVerticle extends EdgeVerticle2 {
     OaiPmhHandler oaiPmhHandler = new OaiPmhHandler(secureStore, ocf, configurationService);
 
     Router router = Router.router(vertx);
-    router.route().handler(BodyHandler.create());
+    router.route().handler(BodyHandler.create()).failureHandler(routingContext ->
+      oaiPmhHandler.oaiPmhFailureHandler(routingContext, routingContext.failure()));
+
 
     router.route(HttpMethod.GET, "/admin/health").handler(this::handleHealthCheck);
     router.route(HttpMethod.GET, "/oai").handler(oaiPmhHandler::handle);

--- a/src/main/java/org/folio/edge/oaipmh/MainVerticle.java
+++ b/src/main/java/org/folio/edge/oaipmh/MainVerticle.java
@@ -23,8 +23,7 @@ public class MainVerticle extends EdgeVerticle2 {
     OaiPmhHandler oaiPmhHandler = new OaiPmhHandler(secureStore, ocf, configurationService);
 
     Router router = Router.router(vertx);
-    router.route().handler(BodyHandler.create()).failureHandler(routingContext ->
-      oaiPmhHandler.oaiPmhFailureHandler(routingContext, routingContext.failure()));
+    router.route().handler(BodyHandler.create());
 
 
     router.route(HttpMethod.GET, "/admin/health").handler(this::handleHealthCheck);

--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -45,6 +45,8 @@ import org.openarchives.oai._2.OAIPMHerrorcodeType;
 import org.openarchives.oai._2.RequestType;
 import org.openarchives.oai._2.VerbType;
 
+import com.google.common.collect.Iterables;
+
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
@@ -71,7 +73,7 @@ public class OaiPmhHandler extends Handler {
     HttpServerRequest request = ctx.request();
     log.debug("Client request: {} {}", request.method(), request.absoluteURI());
     log.debug("Client request parameters: " + request.params());
-    log.debug("Client request headers: " + request.headers());
+    log.debug("Client request headers: " + Iterables.toString(request.headers()));
 
     if (!supportedAcceptHeaders(request)) {
       notAcceptableResponse(ctx, request);
@@ -163,9 +165,9 @@ public class OaiPmhHandler extends Handler {
       response.bodyHandler(buffer -> {
         edgeResponse.end(buffer);
         if (!encodingHeader.isPresent()) {
-          log.debug("Response from oai-pmh response:{} \n {}",response.headers(), buffer);
+          log.debug("Response from oai-pmh headers:{} \n {}", Iterables.toString(response.headers()), buffer);
         }
-        log.debug("Edge response headers: {}", edgeResponse.headers());
+        log.debug("Edge response headers: {}", Iterables.toString(edgeResponse.headers()));
       });
     } else {
       log.error(String.format("Error in the response from repository: (%d)", httpStatusCode));
@@ -183,12 +185,12 @@ public class OaiPmhHandler extends Handler {
   private void badRequest(RoutingContext ctx, String body, String verb, OAIPMHerrorcodeType type) {
     OAIPMH resp = buildBaseResponse(ctx, verb).withErrors(new OAIPMHerrorType().withCode(type)
       .withValue(body));
-    writeResponse(ctx, resp);
+    writeBadRequestResponse(ctx, resp);
   }
 
   private void badRequest(RoutingContext ctx, String verb, List<OAIPMHerrorType> errors) {
     OAIPMH resp = buildBaseResponse(ctx, verb).withErrors(errors);
-    writeResponse(ctx, resp);
+    writeBadRequestResponse(ctx, resp);
   }
 
   @Override
@@ -243,7 +245,7 @@ public class OaiPmhHandler extends Handler {
     }
   }
 
-  private void writeResponse(RoutingContext ctx, OAIPMH respBody) {
+  private void writeBadRequestResponse(RoutingContext ctx, OAIPMH respBody) {
     String xml = null;
     try {
       xml = ResponseHelper.getInstance()

--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -86,7 +86,7 @@ public class OaiPmhHandler extends Handler {
     getOkapiClient(ctx, (okapiClient, notUsed) ->
       configurationService.getEnableOaiServiceConfigSetting(okapiClient)
         .compose(oaiPmhEnabled -> {
-          if (oaiPmhEnabled == false) {
+          if (!oaiPmhEnabled) {
             serviceUnavailableResponse(ctx);
           } else {
             configurationService.associateErrorsWith200Status(okapiClient)

--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -86,7 +86,7 @@ public class OaiPmhHandler extends Handler {
     getOkapiClient(ctx, (okapiClient, notUsed) ->
       configurationService.getEnableOaiServiceConfigSetting(okapiClient)
         .compose(oaiPmhEnabled -> {
-          if (!oaiPmhEnabled) {
+          if (oaiPmhEnabled == false) {
             serviceUnavailableResponse(ctx);
           } else {
             configurationService.associateErrorsWith200Status(okapiClient)

--- a/src/main/java/org/folio/edge/oaipmh/clients/aoipmh/OaiPmhOkapiClient.java
+++ b/src/main/java/org/folio/edge/oaipmh/clients/aoipmh/OaiPmhOkapiClient.java
@@ -17,12 +17,9 @@ import org.folio.edge.oaipmh.domain.Verb;
 import org.folio.edge.oaipmh.utils.Constants;
 import org.openarchives.oai._2.VerbType;
 
-import com.google.common.collect.Iterables;
-
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/org/folio/edge/oaipmh/clients/aoipmh/OaiPmhOkapiClient.java
+++ b/src/main/java/org/folio/edge/oaipmh/clients/aoipmh/OaiPmhOkapiClient.java
@@ -84,24 +84,6 @@ public class OaiPmhOkapiClient extends OkapiClient {
       exceptionHandler);
   }
 
-  @Override
-  public void get(String url, String tenant, MultiMap headers, Handler<HttpClientResponse> responseHandler,
-      Handler<Throwable> exceptionHandler) {
-    HttpClientRequest request = this.client.getAbs(url);
-    if (headers != null) {
-      request.headers()
-        .setAll(this.combineHeadersWithDefaults(headers));
-    } else {
-      request.headers()
-        .setAll(this.defaultHeaders);
-    }
-    log.info("Requesting {}. call request headers: {}", url, Iterables.toString(headers));
-    request.handler(responseHandler)
-      .exceptionHandler(exceptionHandler)
-      .setTimeout(this.reqTimeout)
-      .end();
-  }
-
   /**
    * This method resolves endpoint for 'verb' from {@link VerbType} based on 'verb' value extracted
    * from HTTP GET parameters multimap

--- a/src/main/java/org/folio/edge/oaipmh/clients/aoipmh/OaiPmhOkapiClient.java
+++ b/src/main/java/org/folio/edge/oaipmh/clients/aoipmh/OaiPmhOkapiClient.java
@@ -17,6 +17,8 @@ import org.folio.edge.oaipmh.domain.Verb;
 import org.folio.edge.oaipmh.utils.Constants;
 import org.openarchives.oai._2.VerbType;
 
+import com.google.common.collect.Iterables;
+
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
@@ -93,8 +95,7 @@ public class OaiPmhOkapiClient extends OkapiClient {
       request.headers()
         .setAll(this.defaultHeaders);
     }
-    log.info("Requesting {}. call request headers: {}", url, headers);
-
+    log.info("Requesting {}. call request headers: {}", url, Iterables.toString(headers));
     request.handler(responseHandler)
       .exceptionHandler(exceptionHandler)
       .setTimeout(this.reqTimeout)

--- a/src/main/java/org/folio/edge/oaipmh/clients/modconfiguration/ConfigurationService.java
+++ b/src/main/java/org/folio/edge/oaipmh/clients/modconfiguration/ConfigurationService.java
@@ -6,11 +6,16 @@ import io.vertx.core.Future;
 
 /**
  *  Interface for retrieving oai-pmh configurations from mod-configuration.
+ *  In order to preserve the "old" functionality if the configurations are not present,
+ *  or there are any issues with mod-configuration,the implementations should
+ *  provide default values in case of any errors.
+ *
  */
 public interface ConfigurationService {
 
   /**
-   * This method make request to mod-configuration module and get enableOaiService configuration setting
+   * This method make request to mod-configuration module and get enableOaiService configuration setting.
+   * If any errors occur, the default fallback should be TRUE
    *
    * @param client configuration client which make request to mod-configuration
    * @return value of enableOaiService configuration setting
@@ -18,10 +23,11 @@ public interface ConfigurationService {
   Future<Boolean> getEnableOaiServiceConfigSetting(OkapiClient client);
 
   /**
-   * This method make request to mod-configuration module and get errorsProcessing configuration setting
+   * This method make request to mod-configuration module and get errorsProcessing configuration setting.
+   * If any errors occur, the default fallback value should be FALSE
    *
    * @param client configuration client which make request to mod-configuration
-   * @return value of errorsProcessing configuration setting
+   * @return value of errorsProcessing configuration setting.
    */
   Future<Boolean> associateErrorsWith200Status(OkapiClient client);
 }

--- a/src/main/java/org/folio/edge/oaipmh/clients/modconfiguration/ModConfigurationException.java
+++ b/src/main/java/org/folio/edge/oaipmh/clients/modconfiguration/ModConfigurationException.java
@@ -1,0 +1,11 @@
+package org.folio.edge.oaipmh.clients.modconfiguration;
+
+/**
+ * Indicates exception in communicating with the mod-configuration
+ */
+public class ModConfigurationException extends RuntimeException {
+
+  public ModConfigurationException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/edge/oaipmh/clients/modconfiguration/impl/ModConfigurationService.java
+++ b/src/main/java/org/folio/edge/oaipmh/clients/modconfiguration/impl/ModConfigurationService.java
@@ -46,7 +46,8 @@ public class ModConfigurationService implements ConfigurationService {
         okapiClient.getToken());
     Future<String> future = Future.future();
     final String query = buildQuery(configName);
-    final String msg = String.format("%s?query=%s in tenant %s", okapiClient.okapiURL, query, okapiClient.tenant);
+    final String msg = String.format("Querying setting: %s: %s?query=%s in tenant %s", value, okapiClient.okapiURL, query,
+        okapiClient.tenant);
     log.debug(msg);
     try {
       configurationsClient.getConfigurationsEntries(query, 0, 3, null, null, response -> response.bodyHandler(body -> {
@@ -60,7 +61,7 @@ public class ModConfigurationService implements ConfigurationService {
           .get(0)
           .getValue()).getString(value);
         if (result == null) {
-          throw new ModConfigurationException(msg);
+          throw new ModConfigurationException("Could not find configuration setting " + msg);
         }
         future.complete(result);
       })

--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -487,7 +487,7 @@ public class OaiPmhTest {
       .response();
 
     OAIPMH expectedResp = buildOAIPMHErrorResponse(LIST_IDENTIFIERS, BAD_ARGUMENT,
-      "Missing required parameter: metadataPrefix");
+      "Missing required parameters: metadataPrefix");
     expectedResp.getRequest()
                 .withFrom("2002-05-01T14:15:00Z");
     String expectedRespStr = ResponseHelper.getInstance().writeToString(expectedResp);


### PR DESCRIPTION
## Purpose

The goal of this work is optimize and refactor the previous implementation in which two requests were sent to obtain a token from Okapi. Other changes to the code aim at making the code more compact and readable, improving logging, etc.

The following settings are implemented:

* Associate OAI-PMH level errors with 200 HTTP status
* Implement "Enable OAI service" 

Additionally, a fail-safe mechanism has been added: the existing functionality of the edge module will be working in case of any errors while requesting settings from mod-configuration.

This resolves: MODOAIPMH-106, MODOAIPMH-103

## Follow-up actions:
The institutional user 'diku', which is used by the edge module, needs to have 'configuration.entries.collection.get' permission. Jira: FOLIO-2585



