### PR TITLE
Add 7.0 as acceptable login interface version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "login",
-      "version": "5.0 6.0"
+      "version": "5.0 6.0 7.0"
     },
     {
       "id": "configuration",


### PR DESCRIPTION
## Purpose
https://github.com/folio-org/mod-login/pull/81 includes a breaking change (removal of GET /authn/credentials).  This requires a major interface version bump (login 6.0 -> login 7.0).  In order to prevent dependency issues we need to coordinate this change across several modules and edge APIs.

## Approach
Unless this endpoint is used by a module it's safe to just add 7.0 to the list of allowable versions for the login interface.