### PR TITLE
EDGOAIPMH-48: edge-oai-pmh still requires the configuration interface…

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -10,10 +10,6 @@
     {
       "id": "login",
       "version": "5.0 6.0 7.0"
-    },
-    {
-      "id": "configuration",
-      "version": "2.0"
     }
   ],
   "permissionSets": [],


### PR DESCRIPTION
## PURPOSE

Remove mod-configuration from dependencies in moduledescriptor in edge: https://issues.folio.org/browse/EDGOAIPMH-48.
