### PR TITLE
Tmp release 2.2.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 2.2.1 - Released
+
+This release includes minor bug fixes for edge-oai-pmh module (Q2/2020).
+
 ## 2.2.0 - Released
 
 This release includes transfer of the business logic to the corresponding business module cause edge is a proxy between clients and pmh  (Q2/2020). 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.2.1</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>v2.2.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.3.0-SNAPSHOT</version>
+  <version>2.2.1</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.2.1</tag>
   </scm>
 
   <licenses>


### PR DESCRIPTION
Release edge-oai-pmh-2.2.1: https://issues.folio.org/browse/EDGOAIPMH-49
This release includes minor bug fixes for edge-oai-pmh module (Q2/2020).