### PR TITLE
EDGOAIPMH-60 - Check if the response contains records

### DIFF
--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -9,6 +9,7 @@ import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.folio.edge.core.Constants.TEXT_XML;
+import static org.folio.edge.oaipmh.utils.Constants.METADATA_PREFIX;
 import static org.folio.edge.oaipmh.utils.Constants.RESUMPTION_TOKEN;
 
 import java.io.ByteArrayInputStream;
@@ -68,7 +69,10 @@ public class OaiPmhHandler extends Handler {
 
   private void performCall(RoutingContext ctx, OaiPmhOkapiClient client, String resumptionToken) {
     var request = ctx.request();
-    ofNullable(resumptionToken).ifPresent(token -> request.params().set(RESUMPTION_TOKEN, token));
+    ofNullable(resumptionToken).ifPresent(token -> {
+      request.params().set(RESUMPTION_TOKEN, token);
+      request.params().remove(METADATA_PREFIX);
+    });
     client.call(request.params(), request.headers(),
       response -> handleProxyResponse(ctx, response),
       throwable -> oaiPmhFailureHandler(ctx, throwable));


### PR DESCRIPTION
[EDGOAIPMH-60](https://issues.folio.org/browse/EDGOAIPMH-60) - Check if the response contains records

## Purpose

During the harvesting mod-oai-pmh sends instance uuid to srs to retrieve the underlying record. If the instance does not have underlying SRS record, nothing is included in the output. In some cases when max record per response is small, it might happen that the response will contain resumption token only and no records.
Requirements/Scope:
* Check if the response from mod-oai-pmh contains records and not only resumptionToken
* If there are no records, the module will re-send request to mod-oai-pmh using provided resumptionToken.

## Approach
* Updated logic
* Implemented unit test

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
