### PR TITLE
set pom to next dev iteration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.4.1-SNAPSHOT</version>
+  <version>2.4.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>


### PR DESCRIPTION
SNAPSHOT version in the POM needs to be higher than the last released version (v2.4.1) on master/main.   Setting to 2.4.2-SNAPSHOT. 