### PR TITLE
EDGOAIPMH-77 - Release 2.3.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 ## 2.4.0 (Unreleased)
 
+## 2.3.3 - Released
+
+Primary focus of this release is log4j upgrade
+
+[Full Changelog](https://github.com/folio-org/edge-oai-pmh/compare/v2.3.2...v2.3.3)
+
+### Bug Fixes
+* [EDGOAIPMH-74](https://issues.folio.org/browse/EDGOAIPMH-74) - Kiwi R3 2021 - Log4j edge- modules 2.17.0 upgrade
+
+
 ## 2.3.2 (Released)
 
 Primary focus of this release is fixing log4j vulnerability

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.3.3</version>
+  <version>2.4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>v2.3.3</tag>
+    <tag>v2.3.1</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.16.0</version>
+        <version>2.17.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.4.0-SNAPSHOT</version>
+  <version>2.3.3</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>v2.3.1</tag>
+    <tag>v2.3.3</tag>
   </scm>
 
   <licenses>


### PR DESCRIPTION
[EDGOAIPMH-77](https://issues.folio.org/browse/EDGOAIPMH-77) - Juniper R2 2021 Log4j module release