### PR TITLE
FOLIO-3370 - refenv builds fail, some modules have incorrect snapshot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.4.2-SNAPSHOT</version>
+  <version>2.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>


### PR DESCRIPTION
Upgrading snapshot version to prevent build failure
