### PR TITLE
EDGEOAIPMH-82: Provide a sensible message instead of InternalServerError when the error response from okapi or repository received

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <guava.ver>19.0</guava.ver>
     <jaxb.time.adaptor.ver>1.1.3</jaxb.time.adaptor.ver>
     <junit.ver>4.13.1</junit.ver>
+    <org.junit.jupiter.ver>5.8.1</org.junit.jupiter.ver>
     <mockito.ver>1.9.5</mockito.ver>
     <rest.assured.ver>4.3.0</rest.assured.ver>
     <mod-configuration-client.version>5.1.0</mod-configuration-client.version>
@@ -98,6 +99,18 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.ver}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${org.junit.jupiter.ver}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+      <version>4.2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     <guava.ver>19.0</guava.ver>
     <jaxb.time.adaptor.ver>1.1.3</jaxb.time.adaptor.ver>
     <junit.ver>4.13.1</junit.ver>
-    <org.junit.jupiter.ver>5.8.1</org.junit.jupiter.ver>
     <mockito.ver>1.9.5</mockito.ver>
     <rest.assured.ver>4.3.0</rest.assured.ver>
     <mod-configuration-client.version>5.1.0</mod-configuration-client.version>
@@ -99,18 +98,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.ver}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>${org.junit.jupiter.ver}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-junit5</artifactId>
-      <version>4.2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -43,6 +43,7 @@ public class OaiPmhHandler extends Handler {
 
   /** Expected valid http status codes to be returned by repository logic */
   private static final Set<Integer> EXPECTED_CODES = Set.of(SC_OK, SC_BAD_REQUEST, SC_NOT_FOUND, SC_UNPROCESSABLE_ENTITY, SC_SERVICE_UNAVAILABLE);
+  private static final String ERROR_FROM_REPOSITORY = "Error in the response from repository: status code - %s, response status message - %s";
 
   private OaiPmhOkapiClient oaiPmhClient;
 
@@ -129,8 +130,11 @@ public class OaiPmhHandler extends Handler {
         }
       }
     } else {
-      log.error("Error in the response from repository: status code - {}, response status message - {}", oaiPmhResponse.statusCode(), oaiPmhResponse.statusMessage());
-      internalServerError(ctx, "Internal Server Error");
+      var message = String.format(ERROR_FROM_REPOSITORY,oaiPmhResponse.statusCode(), oaiPmhResponse.statusMessage());
+      log.error(message);
+      if (!ctx.response().ended()) {
+        ctx.response().setStatusCode(500).putHeader(HttpHeaders.CONTENT_TYPE, "text/plain").end(message);
+      }
     }
   }
 

--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -58,8 +58,7 @@ public class OaiPmhTest {
   private static final String BAD_API_KEY = "ZnMwMDAwMDAwMA==0000";
 
   private static final String INVALID_API_KEY_EXPECTED_RESPONSE_BODY = "Invalid API Key: ZnMwMDAwMDAwMA==0000";
-  private static final String EXPECTED_ERROR_FORBIDDEN_MSG = "Error in the response from repository: status code - 403, response status message - Access requires permission: oai-pmh.records.collection.get";
-  private static final String EXPECTED_ERROR_INTERNAL_SERVER_ERROR_MSG = "Error in the response from repository: status code - 500, response status message - Internal Server Error";
+  private static final String EXPECTED_ERROR_MSG = "Error in the response from repository: status code - 403, response status message - Access requires permission: oai-pmh.records.collection.get";
 
   private static Vertx vertx;
   private static OaiPmhMockOkapi mockOkapi;
@@ -329,14 +328,19 @@ public class OaiPmhTest {
   public void testGetRecordOkapiExceptionHttpGet() {
     log.info("=== Test exceptional GetRecord OAI-PMH (HTTP GET) ===");
 
-    RestAssured
+    String expectedMockBody = "Internal Server Error";
+    final Response resp = RestAssured
       .get(String.format("/oai?verb=GetRecord"
         + "&identifier=exception&metadataPrefix=oai_dc&apikey=%s", API_KEY))
       .then()
       .contentType(TEXT_PLAIN)
       .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-      .body(containsString(EXPECTED_ERROR_INTERNAL_SERVER_ERROR_MSG));
+      .extract()
+      .response();
+
+    String actualBody = resp.body().asString();
+    assertEquals(expectedMockBody, actualBody);
   }
 
   @Test
@@ -747,6 +751,6 @@ public class OaiPmhTest {
       .then()
       .contentType(TEXT_PLAIN)
       .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-      .body(containsString(EXPECTED_ERROR_FORBIDDEN_MSG));
+      .body(containsString(EXPECTED_ERROR_MSG));
   }
 }

--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -10,6 +10,7 @@ import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
 import static org.folio.edge.core.Constants.TEXT_PLAIN;
 import static org.folio.edge.core.Constants.TEXT_XML;
 import static org.folio.edge.oaipmh.utils.OaiPmhMockOkapi.REQUEST_TIMEOUT_MS;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -53,6 +54,7 @@ public class OaiPmhTest {
   private static final String BAD_API_KEY = "ZnMwMDAwMDAwMA==0000";
 
   private static final String INVALID_API_KEY_EXPECTED_RESPONSE_BODY = "Invalid API Key: ZnMwMDAwMDAwMA==0000";
+  private static final String EXPECTED_ERROR_MSG = "Error in the response from repository: status code - 403, response status message - Access requires permission: oai-pmh.records.collection.get";
 
   private static Vertx vertx;
   private static OaiPmhMockOkapi mockOkapi;
@@ -705,5 +707,17 @@ public class OaiPmhTest {
 
     String actualBody = resp.body().asString();
     assertEquals(expectedMockBody, actualBody);
+  }
+
+  @Test
+  public void shouldReturnForbidden_whenUserHasMissingPermission() {
+    log.info("=== Test successful ListRecords with empty records response ===");
+
+    RestAssured
+      .get(String.format("/oai?verb=GetRecord&metadataPrefix=marc21&identifier=recordIdForbiddenResponse&apikey=%s", API_KEY))
+      .then()
+      .contentType(TEXT_PLAIN)
+      .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+      .body(containsString(EXPECTED_ERROR_MSG));
   }
 }

--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -32,10 +32,9 @@ import org.folio.edge.oaipmh.utils.OaiPmhMockOkapi;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.runner.RunWith;
 
 import io.restassured.RestAssured;
 import io.restassured.config.DecoderConfig;
@@ -45,12 +44,11 @@ import io.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.junit5.VertxExtension;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@ExtendWith(VertxExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@RunWith(VertxUnitRunner.class)
 public class OaiPmhTest {
 
   private static final String API_KEY = ApiKeyUtils.generateApiKey(10, "diku", "user");
@@ -65,7 +63,7 @@ public class OaiPmhTest {
   private static OaiPmhMockOkapi mockOkapi;
 
   @BeforeClass
-  public void setUpOnce(TestContext context) throws Exception {
+  public static void setUpOnce(TestContext context) throws Exception {
     int okapiPort = TestUtils.getPort();
     int serverPort = TestUtils.getPort();
 
@@ -92,7 +90,7 @@ public class OaiPmhTest {
   }
 
   @AfterClass
-  public void tearDownOnce(TestContext context) {
+  public static void tearDownOnce(TestContext context) {
     log.info("Shutting down server");
     vertx.close(res -> {
       if (res.failed()) {

--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -54,7 +54,8 @@ public class OaiPmhTest {
   private static final String BAD_API_KEY = "ZnMwMDAwMDAwMA==0000";
 
   private static final String INVALID_API_KEY_EXPECTED_RESPONSE_BODY = "Invalid API Key: ZnMwMDAwMDAwMA==0000";
-  private static final String EXPECTED_ERROR_MSG = "Error in the response from repository: status code - 403, response status message - Access requires permission: oai-pmh.records.collection.get";
+  private static final String EXPECTED_ERROR_FORBIDDEN_MSG = "Error in the response from repository: status code - 403, response status message - Access requires permission: oai-pmh.records.collection.get";
+  private static final String EXPECTED_ERROR_INTERNAL_SERVER_ERROR_MSG = "Error in the response from repository: status code - 500, response status message - Internal Server Error";
 
   private static Vertx vertx;
   private static OaiPmhMockOkapi mockOkapi;
@@ -324,19 +325,14 @@ public class OaiPmhTest {
   public void testGetRecordOkapiExceptionHttpGet() {
     log.info("=== Test exceptional GetRecord OAI-PMH (HTTP GET) ===");
 
-    String expectedMockBody = "Internal Server Error";
-    final Response resp = RestAssured
+    RestAssured
       .get(String.format("/oai?verb=GetRecord"
         + "&identifier=exception&metadataPrefix=oai_dc&apikey=%s", API_KEY))
       .then()
       .contentType(TEXT_PLAIN)
       .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-      .extract()
-      .response();
-
-    String actualBody = resp.body().asString();
-    assertEquals(expectedMockBody, actualBody);
+      .body(containsString(EXPECTED_ERROR_INTERNAL_SERVER_ERROR_MSG));
   }
 
   @Test
@@ -718,6 +714,6 @@ public class OaiPmhTest {
       .then()
       .contentType(TEXT_PLAIN)
       .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-      .body(containsString(EXPECTED_ERROR_MSG));
+      .body(containsString(EXPECTED_ERROR_FORBIDDEN_MSG));
   }
 }

--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -32,8 +32,6 @@ import org.folio.edge.oaipmh.utils.OaiPmhMockOkapi;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.runner.RunWith;
 
 import io.restassured.RestAssured;
@@ -131,7 +129,7 @@ public class OaiPmhTest {
     final Response resp = RestAssured
       .get(String.format("/oai?verb=GetRecord" +
         "&identifier=oai:arXiv.org:quant-ph/02131001&metadataPrefix=oai_dc&apikey=%s", API_KEY));
-    resp.then()
+      resp.then()
       .contentType(TEXT_XML)
       .statusCode(HttpStatus.SC_NOT_FOUND)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_XML)
@@ -467,8 +465,8 @@ public class OaiPmhTest {
       .response();
 
     String actualBody = resp.body().asString();
-    String expectedBody = "Accept header must be \"text/xml\" for this request, but it is " + "\"" + unsupportedAcceptType
-      + "\"" + ", can not send */*";
+    String expectedBody = "Accept header must be \"text/xml\" for this request, but it is " +"\""+ unsupportedAcceptType
+      +"\""+", can not send */*";
     assertEquals(expectedBody, actualBody);
   }
 
@@ -544,36 +542,7 @@ public class OaiPmhTest {
     assertEquals(expectedMockBody, actualBody);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings =
-    {
-      "text/*; q=0.2, application/xml, application/xhtml+xml",
-      "text/html, application/xml, text/xml",
-      "text/html, text/html;level=1, */*",
-      "text/*;q=0.3, text/html;level=1, */*;q=0.5"
-    })
-  public void testAcceptHeadersHasDifferentTypos(String header) {
-    Path expectedMockPath = Paths.get(OaiPmhMockOkapi.PATH_TO_GET_RECORDS_MOCK);
-    String expectedMockBody = OaiPmhMockOkapi.getOaiPmhResponseAsXml(expectedMockPath);
-
-    final Response resp = RestAssured
-      .given()
-      .header(HttpHeaders.ACCEPT, header)
-      .get(String.format("/oai?verb=GetRecord"
-        + "&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", API_KEY))
-      .then()
-      .log().all()
-      .contentType(TEXT_XML)
-      .statusCode(HttpStatus.SC_OK)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_XML)
-      .extract()
-      .response();
-
-    String actualBody = resp.body().asString();
-    assertEquals(expectedMockBody, actualBody);
-  }
-
-//  @Test
+  @Test
   public void testAcceptHeaderHasAllTextSybtypesSymbolWithParameterAndWithUnsupportedTypes() {
     log.info("=== Test Accept header has all text sybtypes symbol with parameter and with unsupported types ===");
 
@@ -599,7 +568,7 @@ public class OaiPmhTest {
     assertEquals(expectedMockBody, actualBody);
   }
 
-//  @Test
+  @Test
   public void testAcceptHeaderHasTextTypeXMLAndSomeUnsupportedTypes() {
     log.info("=== Test Accept header has text type XML and some unsupported types ===");
 
@@ -625,7 +594,7 @@ public class OaiPmhTest {
     assertEquals(expectedMockBody, actualBody);
   }
 
-//  @Test
+  @Test
   public void testAcceptHeaderHasAllTypesAndAllSubtypesSymbolAndSomeUnsupportedTypes() {
     log.info("=== Test Accept header has all types and all subtypes symbol and some unsupported types ===");
 
@@ -651,7 +620,7 @@ public class OaiPmhTest {
     assertEquals(expectedMockBody, actualBody);
   }
 
-//  @Test
+  @Test
   public void testAcceptHeaderHasAllTypesAndAllSubtypesSymbolAndAllTextSubtypesSymbolAndSomeUnsupportedTypes() {
     log.info("=== Test Accept header has all types and all subtypes symbol and all text subtypes symbol and some unsupported types ===");
 
@@ -697,8 +666,8 @@ public class OaiPmhTest {
       .response();
 
     String actualBody = resp.body().asString();
-    String expectedBody = "Accept header must be \"text/xml\" for this request, but it is " + "\"" + acceptHeader
-      + "\"" + ", can not send */*";
+    String expectedBody = "Accept header must be \"text/xml\" for this request, but it is " +"\""+ acceptHeader
+      +"\""+", can not send */*";
     assertEquals(expectedBody, actualBody);
   }
 

--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -32,9 +32,10 @@ import org.folio.edge.oaipmh.utils.OaiPmhMockOkapi;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.runner.RunWith;
 
 import io.restassured.RestAssured;
 import io.restassured.config.DecoderConfig;
@@ -44,11 +45,12 @@ import io.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxExtension;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class OaiPmhTest {
 
   private static final String API_KEY = ApiKeyUtils.generateApiKey(10, "diku", "user");
@@ -63,7 +65,7 @@ public class OaiPmhTest {
   private static OaiPmhMockOkapi mockOkapi;
 
   @BeforeClass
-  public static void setUpOnce(TestContext context) throws Exception {
+  public void setUpOnce(TestContext context) throws Exception {
     int okapiPort = TestUtils.getPort();
     int serverPort = TestUtils.getPort();
 
@@ -90,7 +92,7 @@ public class OaiPmhTest {
   }
 
   @AfterClass
-  public static void tearDownOnce(TestContext context) {
+  public void tearDownOnce(TestContext context) {
     log.info("Shutting down server");
     vertx.close(res -> {
       if (res.failed()) {

--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -32,6 +32,8 @@ import org.folio.edge.oaipmh.utils.OaiPmhMockOkapi;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.runner.RunWith;
 
 import io.restassured.RestAssured;
@@ -129,7 +131,7 @@ public class OaiPmhTest {
     final Response resp = RestAssured
       .get(String.format("/oai?verb=GetRecord" +
         "&identifier=oai:arXiv.org:quant-ph/02131001&metadataPrefix=oai_dc&apikey=%s", API_KEY));
-      resp.then()
+    resp.then()
       .contentType(TEXT_XML)
       .statusCode(HttpStatus.SC_NOT_FOUND)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_XML)
@@ -465,8 +467,8 @@ public class OaiPmhTest {
       .response();
 
     String actualBody = resp.body().asString();
-    String expectedBody = "Accept header must be \"text/xml\" for this request, but it is " +"\""+ unsupportedAcceptType
-      +"\""+", can not send */*";
+    String expectedBody = "Accept header must be \"text/xml\" for this request, but it is " + "\"" + unsupportedAcceptType
+      + "\"" + ", can not send */*";
     assertEquals(expectedBody, actualBody);
   }
 
@@ -542,7 +544,36 @@ public class OaiPmhTest {
     assertEquals(expectedMockBody, actualBody);
   }
 
-  @Test
+  @ParameterizedTest
+  @ValueSource(strings =
+    {
+      "text/*; q=0.2, application/xml, application/xhtml+xml",
+      "text/html, application/xml, text/xml",
+      "text/html, text/html;level=1, */*",
+      "text/*;q=0.3, text/html;level=1, */*;q=0.5"
+    })
+  public void testAcceptHeadersHasDifferentTypos(String header) {
+    Path expectedMockPath = Paths.get(OaiPmhMockOkapi.PATH_TO_GET_RECORDS_MOCK);
+    String expectedMockBody = OaiPmhMockOkapi.getOaiPmhResponseAsXml(expectedMockPath);
+
+    final Response resp = RestAssured
+      .given()
+      .header(HttpHeaders.ACCEPT, header)
+      .get(String.format("/oai?verb=GetRecord"
+        + "&identifier=oai:arXiv.org:cs/0112017&metadataPrefix=oai_dc&apikey=%s", API_KEY))
+      .then()
+      .log().all()
+      .contentType(TEXT_XML)
+      .statusCode(HttpStatus.SC_OK)
+      .header(HttpHeaders.CONTENT_TYPE, TEXT_XML)
+      .extract()
+      .response();
+
+    String actualBody = resp.body().asString();
+    assertEquals(expectedMockBody, actualBody);
+  }
+
+//  @Test
   public void testAcceptHeaderHasAllTextSybtypesSymbolWithParameterAndWithUnsupportedTypes() {
     log.info("=== Test Accept header has all text sybtypes symbol with parameter and with unsupported types ===");
 
@@ -568,7 +599,7 @@ public class OaiPmhTest {
     assertEquals(expectedMockBody, actualBody);
   }
 
-  @Test
+//  @Test
   public void testAcceptHeaderHasTextTypeXMLAndSomeUnsupportedTypes() {
     log.info("=== Test Accept header has text type XML and some unsupported types ===");
 
@@ -594,7 +625,7 @@ public class OaiPmhTest {
     assertEquals(expectedMockBody, actualBody);
   }
 
-  @Test
+//  @Test
   public void testAcceptHeaderHasAllTypesAndAllSubtypesSymbolAndSomeUnsupportedTypes() {
     log.info("=== Test Accept header has all types and all subtypes symbol and some unsupported types ===");
 
@@ -620,7 +651,7 @@ public class OaiPmhTest {
     assertEquals(expectedMockBody, actualBody);
   }
 
-  @Test
+//  @Test
   public void testAcceptHeaderHasAllTypesAndAllSubtypesSymbolAndAllTextSubtypesSymbolAndSomeUnsupportedTypes() {
     log.info("=== Test Accept header has all types and all subtypes symbol and all text subtypes symbol and some unsupported types ===");
 
@@ -666,8 +697,8 @@ public class OaiPmhTest {
       .response();
 
     String actualBody = resp.body().asString();
-    String expectedBody = "Accept header must be \"text/xml\" for this request, but it is " +"\""+ acceptHeader
-      +"\""+", can not send */*";
+    String expectedBody = "Accept header must be \"text/xml\" for this request, but it is " + "\"" + acceptHeader
+      + "\"" + ", can not send */*";
     assertEquals(expectedBody, actualBody);
   }
 

--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -58,7 +58,8 @@ public class OaiPmhTest {
   private static final String BAD_API_KEY = "ZnMwMDAwMDAwMA==0000";
 
   private static final String INVALID_API_KEY_EXPECTED_RESPONSE_BODY = "Invalid API Key: ZnMwMDAwMDAwMA==0000";
-  private static final String EXPECTED_ERROR_MSG = "Error in the response from repository: status code - 403, response status message - Access requires permission: oai-pmh.records.collection.get";
+  private static final String EXPECTED_ERROR_FORBIDDEN_MSG = "Error in the response from repository: status code - 403, response status message - Access requires permission: oai-pmh.records.collection.get";
+  private static final String EXPECTED_ERROR_INTERNAL_SERVER_ERROR_MSG = "Error in the response from repository: status code - 500, response status message - Internal Server Error";
 
   private static Vertx vertx;
   private static OaiPmhMockOkapi mockOkapi;
@@ -328,19 +329,14 @@ public class OaiPmhTest {
   public void testGetRecordOkapiExceptionHttpGet() {
     log.info("=== Test exceptional GetRecord OAI-PMH (HTTP GET) ===");
 
-    String expectedMockBody = "Internal Server Error";
-    final Response resp = RestAssured
+    RestAssured
       .get(String.format("/oai?verb=GetRecord"
         + "&identifier=exception&metadataPrefix=oai_dc&apikey=%s", API_KEY))
       .then()
       .contentType(TEXT_PLAIN)
       .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-      .extract()
-      .response();
-
-    String actualBody = resp.body().asString();
-    assertEquals(expectedMockBody, actualBody);
+      .body(containsString(EXPECTED_ERROR_INTERNAL_SERVER_ERROR_MSG));
   }
 
   @Test
@@ -751,6 +747,6 @@ public class OaiPmhTest {
       .then()
       .contentType(TEXT_PLAIN)
       .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-      .body(containsString(EXPECTED_ERROR_MSG));
+      .body(containsString(EXPECTED_ERROR_FORBIDDEN_MSG));
   }
 }

--- a/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java
+++ b/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java
@@ -41,6 +41,8 @@ public class OaiPmhMockOkapi extends MockOkapi {
   private static final String IDENTIFY = "Identify";
   private static final String LIST_RECORDS = "ListRecords";
 
+  private static final String ERROR_MSG_FORBIDDEN = "Access requires permission: oai-pmh.records.collection.get";
+
   public static final long REQUEST_TIMEOUT_MS = 1000L;
 
   public OaiPmhMockOkapi(int port, List<String> knownTenants) {
@@ -129,8 +131,13 @@ public class OaiPmhMockOkapi extends MockOkapi {
         .setStatusCode(200)
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_XML)
         .end(getOaiPmhResponseAsXml(Paths.get(PATH_TO_LIST_RECORDS_EMPTY_MOCK)));
-    }else if (path.contains("TimeoutException")) {
+    } else if (path.contains("TimeoutException")) {
       vertx.setTimer(REQUEST_TIMEOUT_MS + 1L, event -> log.debug("OKAPI client should throw TimeoutException"));
+    } else if (paramsContainVerbWithName(requestParams, GET_RECORD) && paramsContainParamWithValue(requestParams, "recordIdForbiddenResponse")) {
+      ctx.response()
+        .setStatusCode(403)
+        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+        .end(ERROR_MSG_FORBIDDEN);
     }
   }
 

--- a/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java
+++ b/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java
@@ -136,7 +136,6 @@ public class OaiPmhMockOkapi extends MockOkapi {
     } else if (paramsContainVerbWithName(requestParams, GET_RECORD) && paramsContainParamWithValue(requestParams, "recordIdForbiddenResponse")) {
       ctx.response()
         .setStatusCode(403)
-        .setStatusMessage(ERROR_MSG_FORBIDDEN)
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
         .end(ERROR_MSG_FORBIDDEN);
     }

--- a/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java
+++ b/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java
@@ -136,6 +136,7 @@ public class OaiPmhMockOkapi extends MockOkapi {
     } else if (paramsContainVerbWithName(requestParams, GET_RECORD) && paramsContainParamWithValue(requestParams, "recordIdForbiddenResponse")) {
       ctx.response()
         .setStatusCode(403)
+        .setStatusMessage(ERROR_MSG_FORBIDDEN)
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
         .end(ERROR_MSG_FORBIDDEN);
     }


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/EDGOAIPMH-82

### Purpose 
Provide a sensible message in case of error from okapi or a repository instead of the "InternalServerError".