### PR TITLE
EDGEOAIPMH-82: forward the response status code received from okapi instead of 500

### DIFF
--- a/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
+++ b/src/main/java/org/folio/edge/oaipmh/OaiPmhHandler.java
@@ -130,10 +130,10 @@ public class OaiPmhHandler extends Handler {
         }
       }
     } else {
-      var message = String.format(ERROR_FROM_REPOSITORY, oaiPmhResponse.statusCode(), oaiPmhResponse.statusMessage());
+      var message = String.format(ERROR_FROM_REPOSITORY, oaiPmhResponse.statusCode(), oaiPmhResponse.statusMessage() + " " + oaiPmhResponse.bodyAsString());
       log.error(message);
       if (!ctx.response().ended()) {
-        ctx.response().setStatusCode(500).putHeader(HttpHeaders.CONTENT_TYPE, "text/plain").end(message);
+        ctx.response().setStatusCode(oaiPmhResponse.statusCode()).putHeader(HttpHeaders.CONTENT_TYPE, "text/plain").end(message);
       }
     }
   }

--- a/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
+++ b/src/test/java/org/folio/edge/oaipmh/OaiPmhTest.java
@@ -53,7 +53,7 @@ class OaiPmhTest {
   private static final String BAD_API_KEY = "ZnMwMDAwMDAwMA==0000";
 
   private static final String INVALID_API_KEY_EXPECTED_RESPONSE_BODY = "Invalid API Key: ZnMwMDAwMDAwMA==0000";
-  private static final String EXPECTED_ERROR_FORBIDDEN_MSG = "Error in the response from repository: status code - 403, response status message - Access requires permission: oai-pmh.records.collection.get";
+  private static final String EXPECTED_ERROR_FORBIDDEN_MSG = "Error in the response from repository: status code - 403, response status message - Forbidden Access requires permission: oai-pmh.records.collection.get";
   private static final String EXPECTED_ERROR_INTERNAL_SERVER_ERROR_MSG = "Error in the response from repository: status code - 500, response status message - Internal Server Error";
 
   private static OaiPmhMockOkapi mockOkapi;
@@ -610,7 +610,7 @@ class OaiPmhTest {
       .get(String.format("/oai?verb=GetRecord&metadataPrefix=marc21&identifier=recordIdForbiddenResponse&apikey=%s", API_KEY))
       .then()
       .contentType(TEXT_PLAIN)
-      .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+      .statusCode(HttpStatus.SC_FORBIDDEN)
       .body(containsString(EXPECTED_ERROR_FORBIDDEN_MSG));
   }
 }

--- a/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java
+++ b/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java
@@ -44,6 +44,7 @@ public class OaiPmhMockOkapi extends MockOkapi {
   private static final String ERROR_MSG_FORBIDDEN = "Access requires permission: oai-pmh.records.collection.get";
 
   public static final long REQUEST_TIMEOUT_MS = 1000L;
+  private static final String FORBIDDEN_STATUS_MESSAGE = "Forbidden";
 
   private final Vertx vertx;
 
@@ -134,7 +135,7 @@ public class OaiPmhMockOkapi extends MockOkapi {
     } else if (paramsContainVerbWithName(requestParams, GET_RECORD) && paramsContainParamWithValue(requestParams, "recordIdForbiddenResponse")) {
       ctx.response()
         .setStatusCode(403)
-        .setStatusMessage(ERROR_MSG_FORBIDDEN)
+        .setStatusMessage(FORBIDDEN_STATUS_MESSAGE)
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
         .end(ERROR_MSG_FORBIDDEN);
     }


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/EDGOAIPMH-82

### PURPOSE

Proxy the response received from okapi 

**Enhancement**
Append the okapi response body to the edge response, therefore a user will be able to see not only Forbidden message but the message with missing permission like "Error in the response from repository: status code - 403, response status message - Forbidden Access requires permission: oai-pmh.records.collection.get"