### PR TITLE
EDGOAIPMH-87: edge-common 4.4.1 fixing disabled SSL in Vert.x WebClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
     <jaxb-impl.version>2.3.6</jaxb-impl.version>
     <jaxb-core.version>4.0.0</jaxb-core.version>
     <mod-configuration-client.version>5.7.7</mod-configuration-client.version>
-    <edge.common.version>4.3.0</edge.common.version>
-    <vertx-stack-depchain.version>4.3.1</vertx-stack-depchain.version>
+    <edge.common.version>4.4.1</edge.common.version>
+    <vertx-stack-depchain.version>4.3.3</vertx-stack-depchain.version>
     <log4j-bom.version>2.17.2</log4j-bom.version>
     <mockito-core.version>4.6.1</mockito-core.version>
     <rest-assured.version>5.1.0</rest-assured.version>


### PR DESCRIPTION
Upgrade edge-common from 4.3.0 to 4.4.1.

This upgrades Vert.x from 4.3.1 to 4.3.3 fixing disabled SSL in WebClient:
https://github.com/vert-x3/wiki/wiki/4.3.2-Release-Notes#vertx-web

Keep vertx-stack-depchain in sync with the version from edge-common
by upgrading it from 4.3.1 to 4.3.3.