### PR TITLE
EDGOAIPMH-88: Release edge-oai-pmh 2.5.1 for MG Bugfix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 ## 2.6.0 - Unreleased
 
+## 2.5.1 - Released
+
+This release includes bug fixes in the Vert.x dependency.
+
+[Full Changelog](https://github.com/folio-org/edge-oai-pmh/compare/v2.5.0...v2.5.1)
+
+### Bug Fixes
+
+* [EDGOAIPMH-87](https://issues.folio.org/browse/EDGOAIPMH-87) - edge-common 4.4.1 fixing disabled SSL in Vert.x WebClient
+
 ## 2.5.0 - Released
 
 This release includes minor improvements and libraries dependencies update

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.6.0-SNAPSHOT</version>
+  <version>2.5.1</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.5.1</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.5.1</version>
+  <version>2.6.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>v2.5.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>


### PR DESCRIPTION
https://issues.folio.org/browse/EDGOAIPMH-88 Release edge-oai-pmh 2.5.1 for MG Bugfix
https://issues.folio.org/browse/EDGOAIPMH-87 edge-common 4.4.1 fixing disabled SSL in Vert.x WebClient