### PR TITLE
Release 2.6.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,14 @@
-## 2.6.0 - Unreleased
+## 2.7.0 - Unreleased
+
+## 2.6.0 - Released
+
+This release includes logging improvements configuration.
+
+[Full Changelog](https://github.com/folio-org/edge-oai-pmh/compare/v2.5.1...v2.6.0)
+
+### Technical tasks
+
+* [EDGOAIPMH-91](https://issues.folio.org/browse/EDGOAIPMH-91) - Logging improvement - Configuration
 
 ## 2.5.1 - Released
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.6.0</version>
+  <version>2.7.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>v2.6.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <jaxb-impl.version>2.3.6</jaxb-impl.version>
     <jaxb-core.version>4.0.0</jaxb-core.version>
     <mod-configuration-client.version>5.7.7</mod-configuration-client.version>
-    <edge.common.version>4.4.1</edge.common.version>
+    <edge.common.version>4.4.3</edge.common.version>
     <vertx-stack-depchain.version>4.3.3</vertx-stack-depchain.version>
     <log4j-bom.version>2.17.2</log4j-bom.version>
     <mockito-core.version>4.6.1</mockito-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.6.0-SNAPSHOT</version>
+  <version>2.6.0</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.6.0</tag>
   </scm>
 
   <licenses>


### PR DESCRIPTION
[EDGOAIPMH-93](https://issues.folio.org/browse/EDGOAIPMH-93) - edge-oai-pmh: module release