### PR TITLE
EDGOAIPMH-118: Vert.x 4.5.7 fixing netty form POST OOM CVE-2024-29025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <jaxb-core.version>4.0.0</jaxb-core.version>
     <mod-configuration-client.version>5.9.2</mod-configuration-client.version>
     <edge.common.version>4.7.0</edge.common.version>
-    <vertx-stack-depchain.version>4.5.4</vertx-stack-depchain.version>
+    <vertx-stack-depchain.version>4.5.7</vertx-stack-depchain.version>
     <log4j-bom.version>2.23.0</log4j-bom.version>
     <mockito-core.version>4.6.1</mockito-core.version>
     <rest-assured.version>5.1.0</rest-assured.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGOAIPMH-118

Upgrade Vertx from 4.5.4 to 4.5.7. This indirectly upgrades Netty from 4.1.107.Final to 4.1.108.Final fixing netty-codec-http form POST OOM:

https://www.cve.org/CVERecord?id=CVE-2024-29025