### PR TITLE
EDGOAIPMH-137: RMB 35.4.2, Vertx 4.5.24, log4j 2.25.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 ## 2.12.0 - Unreleased
 
+## 2.11.1 - Released
+
+This release contains dependency upgrades fixing security vulnerabilities
+
+### Technical tasks
+* [EDGOAIPMH-137](https://folio-org.atlassian.net/browse/EDGOAIPMH-137) RMB 35.4.2, Vertx 4.5.24, log4j 2.25.3
+
+[Full Changelog](https://github.com/folio-org/edge-oai-pmh/compare/v2.11.0...v2.10.1)
+
 ## 2.11.0 - Released
 
 This release contains upgrade to Java 21 and dependencies upgrading

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.11.1-SNAPSHOT</version>
+  <version>2.11.1</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.11.1</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-oai-pmh</artifactId>
-  <version>2.11.1</version>
+  <version>2.11.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - OAI-PMH</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-oai-pmh.git</developerConnection>
-    <tag>v2.11.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <java.version>21</java.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <raml-module-builder.version>35.4.0</raml-module-builder.version>
+    <raml-module-builder.version>35.4.2</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <maven.jaxb2.plugin.ver>0.14.0</maven.jaxb2.plugin.ver>
@@ -47,8 +47,8 @@
     <mod-configuration-client.version>5.9.2</mod-configuration-client.version>
     <edge.common.version>4.9.0</edge.common.version>
     <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
-    <vertx-stack-depchain.version>4.5.7</vertx-stack-depchain.version>
-    <log4j-bom.version>2.23.1</log4j-bom.version>
+    <vertx-stack-depchain.version>4.5.24</vertx-stack-depchain.version>
+    <log4j-bom.version>2.25.3</log4j-bom.version>
     <mockito-core.version>5.15.2</mockito-core.version>
     <rest-assured.version>5.5.1</rest-assured.version>
     <lombok.version>1.18.36</lombok.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGOAIPMH-137

## Purpose
This fixes multiple security vulnerabilities:

* CVE-2025-58056 netty-codec-http HTTP Request Smuggling
* CVE-2025-68161 log4j-core Improper Validation of Certificate with Host Mismatch
* CVE-2025-11965 vertx-web Files or Directories Accessible to External Parties
* CVE-2026-1002 vertx-core HTTP Request Smuggling
* CVE-2025-11966 vertx-core HTTP Request Smuggling

## Approach
Upgrade raml-module-builder (RMB) from 35.4.0 to 35.4.2.

Upgrade Vert.x from 4.5.7 to 4.5.24.

Upgrade log4j from 2.23.1 to 2.25.3.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] Check logging
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - n/a Were any API paths or methods changed, added or removed?
   - n/a Were there any schema changes?
   - n/a Did any of the interface versions change?
   - n/a Were permissions changed, added, or removed?
   - n/a Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.
